### PR TITLE
Adds a chain parameter to the type.

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -16,6 +16,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
       '-inkey', @resource[:private_key],
       '-name', @resource[:name]
     ]
+    cmd << [ '-certfile', @resource[:chain] ] if @resource[:chain]
     tmpfile = Tempfile.new("#{@resource[:name]}.")
     tmpfile.write(@resource[:password])
     tmpfile.flush

--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -78,6 +78,12 @@ module Puppet
         accompanied by a signed certificate for the keytool provider.'
     end
 
+    newparam(:chain) do
+      desc 'It has been found that some java applications do not properly send
+        intermediary certificate authorities, in this case you can bundle them
+        with the server certificate using this chain parameter.'
+    end
+
     newparam(:password) do
       desc 'The password used to protect the keystore.  If private keys are
         sebsequently also protected this password will be used to attempt
@@ -99,7 +105,7 @@ module Puppet
     # Where we setup autorequires.
     autorequire(:file) do
       auto_requires = []
-      [:private_key, :certificate].each do |param|
+      [:private_key, :certificate, :chain].each do |param|
         if @parameters.include?(param)
           auto_requires << @parameters[param].value
         end


### PR DESCRIPTION
Add the ability to bundle an set of certs into your keystore entry.

  During use of different java based application it was found that not
  all applications will properly send intermediary certificates to
  facilitate validation.  Currently if you are using a certificate that
  is signed by an intermediary the client will get a validation error.
  This patch gets around this issue by just making it so that the entire
  chain is sent as one cert.
