### PR TITLE
Java7 compat

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -20,6 +20,8 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
     tmpfile = Tempfile.new("#{@resource[:name]}.")
     tmpfile.write(@resource[:password])
     tmpfile.flush
+    randfile = Tempfile.new("#{@resource[:name]}.")
+    ENV["RANDFILE"] = randfile.path
     output = Puppet::Util::Execution.execute(
       cmd,
       :stdinfile  => tmpfile.path,
@@ -27,6 +29,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
       :combine    => true
       )
     tmpfile.close!
+    randfile.close!
     return output
   end
 


### PR DESCRIPTION
Please pull this tiny change. The output of "keytool" has changed in Java7, it will print SHA1 fingerprints by default. (See also http://stackoverflow.com/questions/6305938/how-can-i-get-the-md5-fingerprint-from-javas-keytool-not-only-sha-1).
