### PR TITLE
Update Modulefile release number

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-java_ks'
-version '0.0.2'
+version '0.0.3'
 source 'https://github.com/puppetlabs/puppetlabs-java_ks.git'
 author 'puppetlabs'
 license 'APL 2.0'


### PR DESCRIPTION
Version 0.0.3 has been tagged and released to the Forge but it looks like the version number in the Modulefile got missed.

This commit updates the version to 0.0.3 in the Modulefile.
