### PR TITLE
Allow non-composite title

### DIFF
--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -120,13 +120,21 @@ module Puppet
     # composite namevars.
     def self.title_patterns
       identity = lambda {|x| x}
-      [[
-        /^(.*):(.*)$/,
-       [
-         [ :name, identity ],
-         [ :target, identity ]
-       ]
-      ]]
+      [
+        [
+          /^([^:]+)$/,
+          [
+            [ :name, identity ]
+          ]
+        ],
+        [
+          /^(.*):(.*)$/,
+          [
+            [ :name, identity ],
+            [ :target, identity ]
+          ]
+        ]
+      ]
     end
   end
 end


### PR DESCRIPTION
The title should not require a two-part name consisting of both parts of the namevar. The title should be able to be a simple resource title provided that the user supplies name and target in the parameters of the resource declaration.

This commit modifies the title_patterns method to allow simple name titles in addition to composite name:target titles.
