### PR TITLE
Support for executables outside the system default path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 pkg
+metadata.json

--- a/Modulefile
+++ b/Modulefile
@@ -1,8 +1,9 @@
-name    'puppetlabs-java_ks'
-version '1.0.0'
-source 'https://github.com/puppetlabs/puppetlabs-java_ks.git'
+name 'puppetlabs-java_ks'
+version '1.0.1'
+
 author 'puppetlabs'
 license 'ASL 2.0'
+project_page 'https://github.com/puppetlabs/puppetlabs-java_ks'
+source 'https://github.com/puppetlabs/puppetlabs-java_ks.git'
 summary 'Manage arbitrary Java keystore files'
 description 'Uses a combination of keytool and openssl to manage entries in a Java keystore.'
-project_page 'https://github.com/puppetlabs/puppetlabs-java_ks'

--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -102,6 +102,18 @@ module Puppet
       defaultto :false
     end
 
+    newparam(:path) do
+      desc "The search path used for command (keytool, openssl) execution.
+        Paths can be specified as an array or as a '#{File::PATH_SEPARATOR}' separated list."
+
+      # Support both arrays and colon-separated fields.
+      def value=(*values)
+        @value = values.flatten.collect { |val|
+          val.split(File::PATH_SEPARATOR)
+        }.flatten
+      end
+    end
+
     # Where we setup autorequires.
     autorequire(:file) do
       auto_requires = []


### PR DESCRIPTION
This PR solves the problem of using the module with tools installed outside the system path. A typical example is the PE installer which needs to invoke the 'keytool' but it's not visible as a command since it's not on the path.

However, to be able to achieve the new behavior (new optional parameter 'path' which determines where to look for executables in addition to the default system path, similar to the path in the Exec puppet resource), I needed to give up using the "commands" feature for puppet providers since the path is not known at the time when the provider is being validated.
