### PR TITLE
Use better `raise` syntax to suppress compatibility warnings.

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -127,7 +127,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
     if ! @resource[:certificate].nil? and ! @resource[:private_key].nil?
       import_ks
     elsif @resource[:certificate].nil? and ! @resource[:private_key].nil?
-      raise Puppet::Error 'Keytool is not capable of importing a private key without an accomapaning certificate.'
+      raise Puppet::Error, 'Keytool is not capable of importing a private key without an accomapaning certificate.'
     else
       cmd = [
         command_keytool,


### PR DESCRIPTION
Ruby Enterprise (ruby 1.8.7 (2009-06-12 patchlevel 174) [x86_64-linux], MBARI 0x6770, Ruby Enterprise Edition 2009.10) complains about the `raise` lines in the java_ks provider:

```
/var/lib/puppet/lib/puppet/provider/java_ks/keytool.rb:130: warning: parenthesize argument(s) for future version
```

Adding a comma here suppresses the warning and seems to be more in line with Ruby community conventions.

(Neither version of this change cause problems in 1.8.9.)
