### PR TITLE
Adds "Release Notes/Known Bugs" to Changelog, updates file format to markdown, standardizes the format of previous entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,35 @@
-## puppetlabs-java_ks changelog
+##2014-03-04 - Supported Release 1.2.x
+###Summary
 
-Release notes for the puppetlabs-java_ks module
+####Features
 
----------------------------------------
+####Bugfixes
 
-2014-02-12 Release 1.2.1
-========================
+####Known Bugs
+* No known bugs
 
-### Bugfixes
+
+##2014-02-12 - Release 1.2.1
+
+#### Bugfixes
 - Updating specs
 
-2013-09-18 Release 1.2.0
-========================
+
+##2013-09-18 - Release 1.2.0
 
 ### Summary
 This release adds `puppet://` URI support, a few bugfixes, and lots of tests.
 
-### Features
+#### Features
 - `puppet://` URI support for the `chain`, `certificate`, and `private_key` parameters
 
-### Bugfixes
+#### Bugfixes
 - Validate that keystore passwords are > 6 characters (would silent fail before)
 - Fixed corrupted keystore PKCS12 files in some cases.
 - More acceptance tests, unit tests, and rspec-puppet tests.
 
-1.1.0
-=====
+
+##1.1.0
 
 This minor feature provides a number of new features:
 
@@ -46,7 +50,7 @@ Travis-CI support has also been added to improve testing.
 
 ---------------------------------------
 
-0.0.6
-=====
+##0.0.6
+
 
 Fixes an issue with ibm java handling input from stdin on SLES


### PR DESCRIPTION
Per a request to have initial release notes that specifically listed known issues for this PE 3.2 release, and barred by time constraints from automating a pull from open issues in JIRA, this commit adds a Release Note and Known Bug section to the Changelog for the imminent 3.2 release. As it will display on the Forge, updates file type to markdown and standardizes previous entries. Adds template for release notes to be filled in later.
