### PR TITLE
add ability to specify encoding of certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ To use the java_ks module's functionality, declare each java_ks resource you nee
       target       => '/etc/activemq/broker.ks',
       password     => 'puppet',
       trustcacerts => true,
+      encoding => 'der',
     }
   
     java_ks { 'broker.example.com:/etc/activemq/broker.ks':
@@ -112,6 +113,10 @@ Destination file for the keystore. We autorequire the parent directory for conve
 #### `trustcacerts`
 
 Certificate authorities input into a keystore aren’t trusted by default, so if you are adding a CA you need to set this parameter to true.
+
+#### `encoding`
+
+Certificates can have different encodings, which is necessary to specify with the openssl command during the retrieval of the md5 fingerprint from the certificate. This can be pem (default), der, net.
 
 ### Namevars
 

--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -94,7 +94,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
     cmd = [
       command_openssl,
       'x509', '-fingerprint', '-md5', '-noout',
-      '-in', certificate
+      '-in', certificate, '-inform', @resource[:encoding]
     ]
     output = run_command(cmd)
     latest = output.scan(/MD5 Fingerprint=(.*)/)[0][0]

--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -121,6 +121,16 @@ module Puppet
       end
     end
 
+    newparam(:encoding) do
+      desc "The type of encoding applied to this certificate. 
+        Available values are pem,der,net. Default is pem.
+        This is used by openssl when verifying certificate fingerprint."
+
+      newvalues(:pem, :der, :net)
+
+      defaultto :pem
+    end
+
     # Where we setup autorequires.
     autorequire(:file) do
       auto_requires = []


### PR DESCRIPTION
allows the encoding of a certificate to be specified for the openssl
command to retrieve the md5 fingerprint.

Change-Id: I2a3096f207d59d0e050a3be9f38ca94cff6f0008