### PR TITLE
Stop depending on puppet certs to test java_ks

### DIFF
--- a/spec/acceptance/keystore_spec.rb
+++ b/spec/acceptance/keystore_spec.rb
@@ -13,9 +13,11 @@ describe 'managing java keystores', :unless => UNSUPPORTED_PLATFORMS.include?(fa
   end
   it 'creates a keystore' do
     pp = <<-EOS
+      class { 'java':} ->
+
       java_ks { 'puppetca:keystore':
         ensure       => latest,
-        certificate  => "${settings::ssldir}/certs/ca.pem",
+        certificate  => "/tmp/ca.pem",
         target       => '/etc/keystore.ks',
         password     => 'puppet',
         trustcacerts => true,
@@ -31,7 +33,7 @@ describe 'managing java keystores', :unless => UNSUPPORTED_PLATFORMS.include?(fa
       expect(r.exit_code).to be_zero
       expect(r.stdout).to match(/Your keystore contains 1 entry/)
       expect(r.stdout).to match(/Alias name: puppetca/)
-      expect(r.stdout).to match(/CN=Puppet CA/)
+      expect(r.stdout).to match(/CN=Test CA/)
     end
   end
 end

--- a/spec/acceptance/private_key_spec.rb
+++ b/spec/acceptance/private_key_spec.rb
@@ -8,7 +8,7 @@ describe 'managing java private keys', :unless => UNSUPPORTED_PLATFORMS.include?
   case fact('osfamily')
   when "Solaris"
     keytool_path = '/usr/java/bin/'
-    resource_path = "['/usr/java/bin/','/opt/puppet/bin/']"
+    resource_path = "['/usr/java/bin/','/opt/puppet/bin/', '/usr/bin']"
   when "AIX"
     keytool_path = '/usr/java6/bin/'
     resource_path = "['/usr/java6/bin/','/usr/bin/']"
@@ -17,11 +17,13 @@ describe 'managing java private keys', :unless => UNSUPPORTED_PLATFORMS.include?
   end
   it 'creates a private key' do
     pp = <<-EOS
+      class { 'java': } ->
+
       java_ks { 'broker.example.com:/etc/private_key.ks':
         ensure       => latest,
-        certificate  => "${settings::ssldir}/certs/#{hostname}.pem",
-        private_key  => "${settings::ssldir}/private_keys/#{hostname}.pem",
-        password     => 'puppet',
+        certificate  => "/tmp/ca.pem",
+        private_key  => "/tmp/privkey.pem",
+        password     => 'testpass',
         path         => #{resource_path},
       }
     EOS
@@ -30,11 +32,11 @@ describe 'managing java private keys', :unless => UNSUPPORTED_PLATFORMS.include?
   end
 
   it 'verifies the private key' do
-    shell("#{keytool_path}keytool -list -v -keystore /etc/private_key.ks -storepass puppet") do |r|
+    shell("#{keytool_path}keytool -list -v -keystore /etc/private_key.ks -storepass testpass") do |r|
       expect(r.exit_code).to be_zero
       expect(r.stdout).to match(/Alias name: broker\.example\.com/)
       expect(r.stdout).to match(/Entry type: (keyEntry|PrivateKeyEntry)/)
-      expect(r.stdout).to match(/CN=Puppet CA/)
+      expect(r.stdout).to match(/CN=Test CA/)
     end
   end
 end

--- a/spec/acceptance/truststore_spec.rb
+++ b/spec/acceptance/truststore_spec.rb
@@ -15,7 +15,7 @@ describe 'managing java truststores', :unless => UNSUPPORTED_PLATFORMS.include?(
     pp = <<-EOS
       java_ks { 'puppetca:truststore':
         ensure       => latest,
-        certificate  => "${settings::ssldir}/certs/ca.pem",
+        certificate  => "/tmp/ca.pem",
         target       => '/etc/truststore.ts',
         password     => 'puppet',
         trustcacerts => true,
@@ -30,7 +30,7 @@ describe 'managing java truststores', :unless => UNSUPPORTED_PLATFORMS.include?(
       expect(r.exit_code).to be_zero
       expect(r.stdout).to match(/Your keystore contains 1 entry/)
       expect(r.stdout).to match(/Alias name: puppetca/)
-      expect(r.stdout).to match(/CN=Puppet CA/)
+      expect(r.stdout).to match(/CN=Test CA/)
     end
   end
 end

--- a/spec/acceptance/unsupported_spec.rb
+++ b/spec/acceptance/unsupported_spec.rb
@@ -15,7 +15,7 @@ describe 'unsupported distributions and OSes', :if => UNSUPPORTED_PLATFORMS.incl
     pp = <<-EOS
     java_ks { 'puppetca:keystore':
       ensure       => latest,
-      certificate  => "${settings::ssldir}/certs/ca.pem",
+      certificate  => "/tmp/ca.pem",
       target       => '/etc/keystore.ks',
       password     => 'puppet',
       trustcacerts => true,

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -15,6 +15,23 @@ unless ENV['RS_PROVISION'] == 'no' or ENV['BEAKER_provision'] == 'no'
   end
 end
 
+opensslscript =<<EOS
+  require 'openssl'
+  key = OpenSSL::PKey::RSA.new 1024
+  ca = OpenSSL::X509::Certificate.new
+  ca.serial = 1
+  ca.public_key = key.public_key
+  subj = '/CN=Test CA/ST=Denial/L=Springfield/O=Dis/CN=www.example.com'
+  ca.subject = OpenSSL::X509::Name.parse subj
+  ca.issuer = ca.subject
+  ca.not_before = Time.now
+  ca.not_after = ca.not_before + 360
+  ca.sign(key, OpenSSL::Digest::SHA256.new)
+
+  File.open('/tmp/privkey.pem', 'w') { |f| f.write key.to_pem }
+  File.open('/tmp/ca.pem', 'w') { |f| f.write ca.to_pem }
+EOS
+
 RSpec.configure do |c|
   # Project root
   proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
@@ -28,6 +45,8 @@ RSpec.configure do |c|
     puppet_module_install(:source => proj_root, :module_name => 'java_ks')
     hosts.each do |host|
       on host, puppet('module', 'install', 'puppetlabs-java')
+      # Generate private key and CA for keystore
+      on host, "ruby -e \"#{opensslscript}\""
     end
   end
 end


### PR DESCRIPTION
Previously we removed the call to `puppet master` during acceptance
testing setup because it caused conflicts in agent-master multinode
setups. However, we realized that the reason for the call to `puppet
master` in the first place was so that java_ks could use the existing
puppet certs that exist on the puppet master. This patch refactors the
tests to generate a CA and private key itself. This avoids having tests
depend on a certain node configuration.

The alternative is to put the call to `puppet master` back and 
conditionally detect whether the master is already daemonized. 
However I think separating the puppet setup from the testing '
environment is a better solution.

It also adds /usr/bin to the PATH on solaris so that the java_ks type
can use the openssl command in tests on solaris.
