### PR TITLE
Fix solaris 10 tests

### DIFF
--- a/spec/acceptance/keystore_spec.rb
+++ b/spec/acceptance/keystore_spec.rb
@@ -13,8 +13,6 @@ describe 'managing java keystores', :unless => UNSUPPORTED_PLATFORMS.include?(fa
   end
   it 'creates a keystore' do
     pp = <<-EOS
-      class { 'java':} ->
-
       java_ks { 'puppetca:keystore':
         ensure       => latest,
         certificate  => "/tmp/ca.pem",

--- a/spec/acceptance/private_key_spec.rb
+++ b/spec/acceptance/private_key_spec.rb
@@ -17,8 +17,6 @@ describe 'managing java private keys', :unless => UNSUPPORTED_PLATFORMS.include?
   end
   it 'creates a private key' do
     pp = <<-EOS
-      class { 'java': } ->
-
       java_ks { 'broker.example.com:/etc/private_key.ks':
         ensure       => latest,
         certificate  => "/tmp/ca.pem",

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -46,7 +46,10 @@ RSpec.configure do |c|
     hosts.each do |host|
       on host, puppet('module', 'install', 'puppetlabs-java')
       # Generate private key and CA for keystore
-      on host, "ruby -e \"#{opensslscript}\""
+      path = '${PATH}'
+      path = "/opt/csw/bin:#{path}" # Need ruby's path on solaris 10 (foss)
+      path = "/opt/puppet/bin:#{path}" # But try PE's ruby first
+      on host, "PATH=#{path} ruby -e \"#{opensslscript}\""
     end
   end
 end


### PR DESCRIPTION
As long as basic_spec.rb runs before the other acceptance tests, we
don't need to include the java class in the other tests. This patch
removes the java class from the other tests since it is not supported
on solaris 10. It also fixes the PATH so that we can find ruby on
solaris 10, foss or PE.
