### PR TITLE
Only install modules on masters during tests

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -44,7 +44,7 @@ RSpec.configure do |c|
     # Install module and dependencies
     puppet_module_install(:source => proj_root, :module_name => 'java_ks')
     hosts.each do |host|
-      on host, puppet('module', 'install', 'puppetlabs-java')
+      on host, puppet('module', 'install', 'puppetlabs-java') if host['roles'].include?('master')
       # Generate private key and CA for keystore
       on host, "ruby -e \"#{opensslscript}\""
     end


### PR DESCRIPTION
This should fix failed puppet module installs on solaris 11 and
windows.
