### PR TITLE
Add an option to provide a password for keys in the keystore

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The password used to protect the keystore. If private keys are also protected, t
 
 Used as an alternative to `password` here you can specify a plaintext file where the password is stored.
 
-#### `ks_keypassword`
+#### `destkeypass`
 
 The password you want to set to protect the key in the keystore.
 

--- a/README.md
+++ b/README.md
@@ -91,11 +91,15 @@ The `ensure` parameter accepts three attributes: absent, present, and latest.  L
 
 #### `password`
 
-The password used to protect the keystore. If private keys are also protected, this password will be used to attempt to unlock them. 
+The password used to protect the keystore. If private keys are also protected, this password will be used to attempt to unlock them.
 
 #### `password_file`
 
 Used as an alternative to `password` here you can specify a plaintext file where the password is stored.
+
+#### `ks_keypassword`
+
+The password you want to set to protect the key in the keystore.
 
 #### `path`
 

--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -63,6 +63,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
       '-alias', @resource[:name]
     ]
     cmd << '-trustcacerts' if @resource[:trustcacerts] == :true
+    cmd += [ '-destkeypass', @resource[:ks_keypassword] ] unless @resource[:ks_keypassword].nil?
 
     pwfile = password_file
     run_command(cmd, @resource[:target], pwfile)

--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -63,7 +63,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
       '-alias', @resource[:name]
     ]
     cmd << '-trustcacerts' if @resource[:trustcacerts] == :true
-    cmd += [ '-destkeypass', @resource[:ks_keypassword] ] unless @resource[:ks_keypassword].nil?
+    cmd += [ '-destkeypass', @resource[:destkeypass] ] unless @resource[:destkeypass].nil?
 
     pwfile = password_file
     run_command(cmd, @resource[:target], pwfile)

--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -95,11 +95,11 @@ module Puppet
       end
     end
 
-    newparam(:ks_keypassword) do
+    newparam(:destkeypass) do
       desc 'The password used to protect the key in keystore.'
 
       validate do |value|
-        raise Puppet::Error, "ks_keypassword is #{value.length} characters long; must be of length 6 or greater" if value.length < 6
+        raise Puppet::Error, "destkeypass is #{value.length} characters long; must be of length 6 or greater" if value.length < 6
       end
     end
 

--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -95,6 +95,14 @@ module Puppet
       end
     end
 
+    newparam(:ks_keypassword) do
+      desc 'The password used to protect the key in keystore.'
+
+      validate do |value|
+        raise Puppet::Error, "ks_keypassword is #{value.length} characters long; must be of length 6 or greater" if value.length < 6
+      end
+    end
+
     newparam(:password_file) do
       desc 'The path to a file containing the password used to protect the
         keystore. This cannot be used together with :password.'

--- a/spec/acceptance/destkeypass_spec.rb
+++ b/spec/acceptance/destkeypass_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper_acceptance'
+
+hostname = default.node_name
+
+describe 'password protected java private keys', :unless => UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem')) do
+  let(:confdir)    { default['puppetpath']    }
+  let(:modulepath) { default['distmoduledir'] }
+  case fact('osfamily')
+  when "Solaris"
+    keytool_path = '/usr/java/bin/'
+    resource_path = "['/usr/java/bin/','/opt/puppet/bin/', '/usr/bin']"
+  when "AIX"
+    keytool_path = '/usr/java6/bin/'
+    resource_path = "['/usr/java6/bin/','/usr/bin/']"
+  else
+    resource_path = "undef"
+  end
+  it 'creates a password protected private key' do
+    pp = <<-EOS
+      java_ks { 'broker.example.com:/etc/private_key.ks':
+        ensure       => latest,
+        certificate  => "/tmp/ca.pem",
+        private_key  => "/tmp/privkey.pem",
+        password     => 'testpass',
+        destkeypass  => 'testkeypass',
+        path         => #{resource_path},
+      }
+    EOS
+
+    apply_manifest(pp, :catch_failures => true)
+  end
+
+  it 'can make a cert req with the right password' do
+    shell("#{keytool_path}keytool -certreq -alias broker.example.com -v "\
+     "-keystore /etc/private_key.ks -storepass testpass -keypass testkeypass") do |r|
+      expect(r.exit_code).to be_zero
+      expect(r.stdout).to match(/-BEGIN NEW CERTIFICATE REQUEST-/)
+    end
+  end
+
+  it 'cannot make a cert req with the wrong password' do
+    shell("#{keytool_path}keytool -certreq -alias broker.example.com -v "\
+     "-keystore /etc/private_key.ks -storepass testpass -keypass qwert",
+     :acceptable_exit_codes => 1)
+  end
+
+end

--- a/spec/unit/puppet/provider/java_ks/keytool_spec.rb
+++ b/spec/unit/puppet/provider/java_ks/keytool_spec.rb
@@ -93,6 +93,20 @@ describe Puppet::Type.type(:java_ks).provider(:keytool) do
         )
         provider.import_ks
       end
+
+      it 'should use destkeypass when provided' do
+        dkp = resource.dup
+        dkp[:destkeypass] = 'keypass'
+        provider.expects(:to_pkcs12).with('/tmp/testing.stuff')
+        provider.expects(:run_command).with([
+            'mykeytool', '-importkeystore', '-srcstoretype', 'PKCS12',
+            '-destkeystore', dkp[:target],
+            '-srckeystore', '/tmp/testing.stuff',
+            '-alias', dkp[:name], '-destkeypass', dkp[:destkeypass]
+          ], any_parameters
+        )
+        provider.import_ks
+      end
     end
   end
 

--- a/spec/unit/puppet/type/java_ks_spec.rb
+++ b/spec/unit/puppet/type/java_ks_spec.rb
@@ -9,6 +9,7 @@ describe Puppet::Type.type(:java_ks) do
       :name        => 'app.example.com',
       :target      => '/tmp/application.jks',
       :password    => 'puppet',
+      :destkeypass => 'keypass',
       :certificate => '/tmp/app.example.com.pem',
       :private_key => '/tmp/private/app.example.com.pem',
       :provider    => :keytool
@@ -27,7 +28,7 @@ describe Puppet::Type.type(:java_ks) do
 
   describe 'when validating attributes' do
 
-    [:name, :target, :private_key, :certificate, :password, :password_file, :trustcacerts].each do |param|
+    [:name, :target, :private_key, :certificate, :password, :password_file, :trustcacerts, :destkeypass].each do |param|
       it "should have a #{param} parameter" do
         expect(Puppet::Type.type(:java_ks).attrtype(param)).to eq(:param)
       end
@@ -108,6 +109,15 @@ describe Puppet::Type.type(:java_ks) do
         Puppet::Type.type(:java_ks).new(jks)
       }.to raise_error(Puppet::Error, /length 6/)
     end
+
+    it 'should fail if :destkeypass is fewer than 6 characters' do
+      jks = jks_resource.dup
+      jks[:destkeypass] = 'aoeui'
+      expect {
+        Puppet::Type.type(:java_ks).new(jks)
+      }.to raise_error(Puppet::Error, /length 6/)
+    end
+
   end
 
   describe 'when ensure is set to latest' do


### PR DESCRIPTION
If set append the -destkeypass option when importing keys to the keystore.
This is not for security, but because certain applications require password protected key entries in the keystore.