### PR TITLE
MODULES-618 - fix java_ks when using password_file

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -81,9 +81,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
       '-alias', @resource[:name]
     ]
     begin
-      tmpfile = Tempfile.new("#{@resource[:name]}.")
-      tmpfile.write(@resource[:password])
-      tmpfile.flush
+      tmpfile = password_file
       run_command(cmd, false, tmpfile)
       tmpfile.close!
       return true
@@ -113,9 +111,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
       '-keystore', @resource[:target],
       '-alias', @resource[:name]
     ]
-    tmpfile = Tempfile.new("#{@resource[:name]}.")
-    tmpfile.write(@resource[:password])
-    tmpfile.flush
+    tmpfile = password_file
     output = run_command(cmd, false, tmpfile)
     tmpfile.close!
     current = output.scan(/Certificate fingerprints:\n\s+MD5:  (.*)/)[0][0]
@@ -138,13 +134,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
         '-keystore', @resource[:target]
       ]
       cmd << '-trustcacerts' if @resource[:trustcacerts] == :true
-      tmpfile = Tempfile.new("#{@resource[:name]}.")
-      if File.exists?(@resource[:target]) and not File.zero?(@resource[:target])
-        tmpfile.write(@resource[:password])
-      else
-        tmpfile.write("#{@resource[:password]}\n#{@resource[:password]}")
-      end
-      tmpfile.flush
+      tmpfile = password_file
       run_command(cmd, @resource[:target], tmpfile)
       tmpfile.close!
     end
@@ -157,9 +147,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
       '-alias', @resource[:name],
       '-keystore', @resource[:target]
     ]
-    tmpfile = Tempfile.new("#{@resource[:name]}.")
-    tmpfile.write(@resource[:password])
-    tmpfile.flush
+    tmpfile = password_file
     run_command(cmd, false, tmpfile)
     tmpfile.close!
   end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -33,8 +33,20 @@ opensslscript =<<EOS
   ca.not_after = ca.not_before + 360
   ca.sign(key, OpenSSL::Digest::SHA256.new)
 
+  key2 = OpenSSL::PKey::RSA.new 1024
+  ca2 = OpenSSL::X509::Certificate.new
+  ca2.serial = 2
+  ca2.public_key = key2.public_key
+  subj2 = '/CN=Test CA/ST=Denial/L=Springfield/O=Dis/CN=www.example.com'
+  ca2.subject = OpenSSL::X509::Name.parse subj2
+  ca2.issuer = ca2.subject
+  ca2.not_before = Time.now
+  ca2.not_after = ca2.not_before + 360
+  ca2.sign(key2, OpenSSL::Digest::SHA256.new)
+
   File.open('/tmp/privkey.pem', 'w') { |f| f.write key.to_pem }
   File.open('/tmp/ca.pem', 'w') { |f| f.write ca.to_pem }
+  File.open('/tmp/ca2.pem', 'w') { |f| f.write ca2.to_pem }
 EOS
 
 RSpec.configure do |c|


### PR DESCRIPTION
Anywhere we were using @resource[:password] in the provider use password_file instead. Make sure we try using password_file.

Fixes puppetlabs/puppetlabs-java_ks#59
