### PR TITLE
update README to reflect that java 7 works as of 1.0.0/310b89b

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ Limitations
 
 The java_ks module uses the `keytool` and `openssl` commands. It should work on all systems with these commands. 
 
-At the moment, Java 7 isn't fully supported, and `ensure => latest` will fail.
+Java 7 is supported as of 1.0.0.
 
-Only validated against IBM Java 6 on AIX. Other versions may be unsupported.
+Developed against IBM Java 6 on AIX. Other versions may be unsupported.
 
 Development
 -----------


### PR DESCRIPTION
Had to dig through code/old PRs to find that ensure => latest on Java 7 does actually work as of 1.0.0; update README to prevent others the trouble.