### PR TITLE
edits to descriptions of params

### DIFF
--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -1,11 +1,11 @@
 module Puppet
   newtype(:java_ks) do
-    @doc = 'Manages entries in a java keystore.  Uses composite namevars to
-        accomplish the same alias spread across multiple target keystores.'
+    @doc = 'Manages the entries in a java keystore, and uses composite namevars to 
+    accomplish the same alias spread across multiple target keystores.'
 
     ensurable do
 
-      desc 'Has three states, the obvious present and absent plus latest.  Latest
+      desc 'Has three states: present, absent, and latest.  Latest
         will compare the on disk MD5 fingerprint of the certificate and to that
         in keytool to determine if insync? returns true or false.  We redefine
         insync? for this paramerter to accomplish this.'
@@ -48,8 +48,8 @@ module Puppet
     end
 
     newparam(:name) do
-      desc 'The alias that is used to identify the entry in the keystore.  We
-        are down casing it for you here because keytool will do so for you too.'
+      desc 'The alias that is used to identify the entry in the keystore. This will be
+      converted to lowercase.'
 
       isnamevar
 
@@ -59,50 +59,48 @@ module Puppet
     end
 
     newparam(:target) do
-      desc 'Destination file for the keystore.  We autorequire the parent
-        directory for convenience.'
+      desc 'Destination file for the keystore.  This will autorequire the parent directory of the file.'
 
       isnamevar
     end
 
     newparam(:certificate) do
-      desc 'An already signed certificate that we can place in the keystore.  We
-        autorequire the file for convenience.'
+      desc 'An already signed certificate that we can place in the keystore.  This will autorequire the specified file.'
 
       isrequired
     end
 
     newparam(:private_key) do
-      desc 'If you desire for an application to be a server and encrypt traffic
+      desc 'If you want an application to be a server and encrypt traffic,
         you will need a private key.  Private key entries in a keystore must be
-        accompanied by a signed certificate for the keytool provider.'
+        accompanied by a signed certificate for the keytool provider. This will autorequire the specified file.'
     end
 
     newparam(:chain) do
-      desc 'It has been found that some java applications do not properly send
+      desc 'Some java applications do not properly send
         intermediary certificate authorities, in this case you can bundle them
-        with the server certificate using this chain parameter.'
+        with the server certificate using chain. This will autorequire the specified file.'
     end
 
     newparam(:password) do
       desc 'The password used to protect the keystore.  If private keys are
         subsequently also protected this password will be used to attempt
-        unlocking...P.S. Let me know if you ever need a separate private key
-        password parameter...'
+        unlocking. Must be six or more characters in length. Cannot be used
+        together with :password_file, but you must pass at least one of these parameters.'
 
       validate do |value|
-        raise Puppet::Error, "password is #{value.length} characters long; must be of length 6 or greater" if value.length < 6
+        raise Puppet::Error, "password is #{value.length} characters long; must be 6 characters or greater in length" if value.length < 6
       end
     end
 
     newparam(:password_file) do
       desc 'The path to a file containing the password used to protect the
-        keystore. This cannot be used together with :password.'
+        keystore. This cannot be used together with :password, but you must pass at least one of these parameters.'
     end
 
     newparam(:trustcacerts) do
-      desc "When inputing certificate authorities into a keystore, they aren't
-        by default trusted so if you are adding a CA you need to set this to true."
+      desc "Certificate authorities aren't by default trusted so if you are adding a CA you need to set this to true.
+       Defaults to :false."
 
       newvalues(:true, :false)
 

--- a/spec/unit/puppet/type/java_ks_spec.rb
+++ b/spec/unit/puppet/type/java_ks_spec.rb
@@ -106,7 +106,7 @@ describe Puppet::Type.type(:java_ks) do
       jks[:password] = 'aoeui'
       expect {
         Puppet::Type.type(:java_ks).new(jks)
-      }.to raise_error(Puppet::Error, /length 6/)
+      }.to raise_error(Puppet::Error, /6 characters/)
     end
   end
 


### PR DESCRIPTION
These are pre-readme changes. Since the forge is (for now) displaying types and descriptions, the developer-created descriptions are now customer facing. Editing these descriptions first, then I will create a PR from this merge that reflects changes to the README.md file. 