### PR TITLE
(MODULES-2561) resolve title properly when on windows

### DIFF
--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -152,6 +152,13 @@ Puppet::Type.newtype(:java_ks) do
         ]
       ],
       [
+        /^(.*):([a-z]:(\/|\\).*)$/i,
+        [
+            [ :name, identity ],
+            [ :target, identity ]
+        ]
+      ],
+      [
         /^(.*):(.*)$/,
         [
           [ :name, identity ],

--- a/spec/acceptance/destkeypass_spec.rb
+++ b/spec/acceptance/destkeypass_spec.rb
@@ -4,17 +4,17 @@ hostname = default.node_name
 
 describe 'password protected java private keys', :unless => UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem')) do
   include_context 'common variables'
- 
+
   let(:confdir)    { default['puppetpath']    }
   let(:modulepath) { default['distmoduledir'] }
-  
+
   case fact('osfamily')
     when "windows"
       target = 'c:/private_key.ks'
     else
       target = '/etc/private_key.ks'
   end
-  
+
   it 'creates a password protected private key' do
     pp = <<-EOS
       java_ks { 'broker.example.com:#{target}':


### PR DESCRIPTION
- Lambda expression match was not restrictive enough to
  match properly for windows and was splitting on second ':'
  and not the first, this addes a new pattern match for windows
  that expects a letter based path in the title i.e. 'C:\tmp'