### PR TITLE
Support for systems running in FIPS mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ All parameters, except where specified, are optional.
 Takes intermediate certificate authorities from a separate file from the server certificate. This autorequires the file of the same path and must be present on the node before java_ks{} is run. Valid options: string. Default: undef.
 
 #####`ensure`
-Valid options: absent, present, latest. Latest verifies md5 certificate fingerprints for the stored certificate and the source file. Default: present.
+Valid options: absent, present, latest. Latest verifies sha256 certificate fingerprints for the stored certificate and the source file. Default: present.
 
 #####`name`
 *Required.* Identifies the entry in the keystore. This will be converted to lowercase. Valid options: string. Default: undef.  

--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -127,7 +127,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
           '-v', '-printcert', '-file', certificate
       ]
       output = run_command(cmd)
-      latest = output.scan(/MD5:\s+(.*)/)[0][0]
+      latest = output.scan(/SHA256:\s+(.*)/)[0][0]
       return latest
     end
   end
@@ -148,7 +148,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
       tmpfile = password_file
       output = run_command(cmd, false, tmpfile)
       tmpfile.close!
-      current = output.scan(/Certificate fingerprints:\n\s+MD5:  (.*)/)[0][0]
+      current = output.scan(/Certificate fingerprints:\n\s+MD5:  .*\n\s+SHA1: .*\n\s+SHA256: (.*)/)[0][0]
       return current
     end
   end

--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -5,7 +5,7 @@ Puppet::Type.newtype(:java_ks) do
   ensurable do
 
     desc 'Has three states: present, absent, and latest.  Latest
-      will compare the on disk MD5 fingerprint of the certificate to that
+      will compare the on disk SHA256 fingerprint of the certificate to that
       in keytool to determine if insync? returns true or false.  We redefine
       insync? for this paramerter to accomplish this.'
 

--- a/spec/unit/puppet/type/java_ks_spec.rb
+++ b/spec/unit/puppet/type/java_ks_spec.rb
@@ -122,11 +122,11 @@ describe Puppet::Type.type(:java_ks) do
   end
 
   describe 'when ensure is set to latest' do
-    it 'insync? should return false if md5 fingerprints do not match and state is :present' do
+    it 'insync? should return false if sha256 fingerprints do not match and state is :present' do
       jks = jks_resource.dup
       jks[:ensure] = :latest
-      @provider.stubs(:latest).returns('AF:61:1C:FF:C7:C0:B2:C6:37:C5:D1:6E:00:AB:7A:B2')
-      @provider.stubs(:current).returns('B4:54:EB:55:86:41:84:2E:22:A0:6A:36:1B:28:47:76')
+      @provider.stubs(:latest).returns('7A:4A:0B:29:66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A:E7:8F:6A:AE:82:12:EE:3C:7C:C2:56:94:77')
+      @provider.stubs(:current).returns('10:84:17:2A:A5:23:15:82:1C:1E:72:5E:21:21:46:45:65:57:50:FE:2D:DA:7C:C8:57:D2:33:3A:B0:A6:7F:1C')
       expect(Puppet::Type.type(:java_ks).new(jks).property(:ensure).insync?(:present)).to be_falsey
     end
 
@@ -136,11 +136,11 @@ describe Puppet::Type.type(:java_ks) do
       expect(Puppet::Type.type(:java_ks).new(jks).property(:ensure).insync?(:absent)).to be_falsey
     end
 
-    it 'insync? should return true if md5 fingerprints match and state is :present' do
+    it 'insync? should return true if sha256 fingerprints match and state is :present' do
       jks = jks_resource.dup
       jks[:ensure] = :latest
-      @provider.stubs(:latest).returns('AF:61:1C:FF:C7:C0:B2:C6:37:C5:D1:6E:00:AB:7A:B2')
-      @provider.stubs(:current).returns('AF:61:1C:FF:C7:C0:B2:C6:37:C5:D1:6E:00:AB:7A:B2')
+      @provider.stubs(:latest).returns('7A:4A:0B:29:66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A:E7:8F:6A:AE:82:12:EE:3C:7C:C2:56:94:77')
+      @provider.stubs(:current).returns('7A:4A:0B:29:66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A:E7:8F:6A:AE:82:12:EE:3C:7C:C2:56:94:77')
       expect(Puppet::Type.type(:java_ks).new(jks).property(:ensure).insync?(:present)).to be_truthy
     end
   end


### PR DESCRIPTION
I ran into problems running older versions of this module on Linux systems running in FIPS mode because of the use of MD5 with openssl.  While the call to openssl to look at the current key fingerprint is no longer present, the dependency on MD5 for anything within FIPS mode systems can cause issues.  Keytool provides key fingerprints in MD5, SHA1, and SHA256, so there doesn't seem like any reason not to switch to a SHA2 algorithm.