### PR TITLE
Support EC keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To have a Java application server use a specific certificate for incoming connec
 
 The java_ks module supports multiple certificates with different keystores but the same alias by implementing Puppet's composite namevar functionality.  Titles map to namevars via `$alias:$target` (alias of certificate, colon, on-disk path to the keystore). If you create dependencies on these resources you need to remember to use the same title syntax outlined for generating the composite namevars.
 
-*Note about composite namevars:*  
+*Note about composite namevars:*
 The way composite namevars currently work, you must have the colon in the title. This is true *even if you define name and target parameters.*  The title can be `foo:bar`, but the name and target parameters must be `broker.example.com` and `/etc/activemq/broker.ks`. If you follow convention, it will do as you expect and correctly create an entry in the
 broker.ks keystore with the alias of broker.example.com.
 
@@ -91,7 +91,7 @@ Takes intermediate certificate authorities from a separate file from the server 
 Valid options: absent, present, latest. Latest verifies sha256 certificate fingerprints for the stored certificate and the source file. Default: present.
 
 #####`name`
-*Required.* Identifies the entry in the keystore. This will be converted to lowercase. Valid options: string. Default: undef.  
+*Required.* Identifies the entry in the keystore. This will be converted to lowercase. Valid options: string. Default: undef.
 
 #####`password`
 This password is used to protect the keystore. If private keys are also protected, this password will be used to attempt to unlock them. Valid options: String. Must be 6 or more characters. This cannot be used together with `password_file`, but *you must pass at least one of these parameters.* Default: undef.
@@ -107,6 +107,10 @@ Used for command (keytool, openssl) execution. Valid options: array or file path
 
 #####`private_key`
 Sets a private key that encrypts traffic to a server application. Must be accompanied by a signed certificate for the keytool provider. This autorequires the specified file and must be present on the node before java_ks{} is run. Valid options: string. Default: undef.
+
+#####`private_key_type`
+
+Set the type of the private key. Usually this is RSA but EC (Elliptic Curve) keys are also supported. Valid options: `rsa` and `ec`. Default: `rsa`.
 
 #####`target`
 *Required.* Specifies a destination file for the keystore. Autorequires the parent directory of the file. Valid options: string. Default: undef.
@@ -139,6 +143,6 @@ Developed against IBM Java 6 on AIX. Other versions may be unsupported.
 Development
 -----------
 
-Puppet Labs modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can’t access the huge number of platforms and myriad hardware, software, and deployment configurations that Puppet is intended to serve.  
+Puppet Labs modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can’t access the huge number of platforms and myriad hardware, software, and deployment configurations that Puppet is intended to serve.
 
 We want to keep it as easy as possible to contribute changes so that our modules work in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things. For more information, see our [module contribution guide.](https://docs.puppetlabs.com/forge/contributing.html)

--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -83,6 +83,16 @@ Puppet::Type.newtype(:java_ks) do
       accompanied by a signed certificate for the keytool provider. This will autorequire the specified file.'
   end
 
+  newparam(:private_key_type) do
+    desc 'The type of the private key. Usually the private key is of type RSA
+      key but it can also be an Elliptic Curve key (EC).
+      Valid options: <rsa>, <ec>. Defaults to <rsa>'
+
+    newvalues(:rsa, :ec)
+
+    defaultto :rsa
+  end
+
   newparam(:chain) do
     desc 'The intermediate certificate authorities, if they are to be taken
       from a file separate from the server certificate. This will autorequire the specified file.'

--- a/spec/unit/puppet/type/java_ks_spec.rb
+++ b/spec/unit/puppet/type/java_ks_spec.rb
@@ -12,6 +12,7 @@ describe Puppet::Type.type(:java_ks) do
       :destkeypass => 'keypass',
       :certificate => '/tmp/app.example.com.pem',
       :private_key => '/tmp/private/app.example.com.pem',
+      :private_key_type => 'rsa',
       :storetype   => 'jceks',
       :provider    => :keytool
     }
@@ -29,7 +30,7 @@ describe Puppet::Type.type(:java_ks) do
 
   describe 'when validating attributes' do
 
-    [:name, :target, :private_key, :certificate, :password, :password_file, :trustcacerts, :destkeypass].each do |param|
+    [:name, :target, :private_key, :private_key_type, :certificate, :password, :password_file, :trustcacerts, :destkeypass].each do |param|
       it "should have a #{param} parameter" do
         expect(Puppet::Type.type(:java_ks).attrtype(param)).to eq(:param)
       end
@@ -40,6 +41,7 @@ describe Puppet::Type.type(:java_ks) do
         expect(Puppet::Type.type(:java_ks).attrtype(prop)).to eq(:property)
       end
     end
+
   end
 
   describe 'when validating attribute values' do
@@ -82,9 +84,22 @@ describe Puppet::Type.type(:java_ks) do
       jks[:name] = 'APP.EXAMPLE.COM'
       expect(Puppet::Type.type(:java_ks).new(jks)[:name]).to eq(jks_resource[:name])
     end
- 
+
     it 'should have :false value to :trustcacerts when parameter not provided' do
       expect(Puppet::Type.type(:java_ks).new(jks_resource)[:trustcacerts]).to eq(:false)
+    end
+
+    it 'should have :rsa as the default value for :private_key_type' do
+      expect(Puppet::Type.type(:java_ks).new(jks_resource)[:private_key_type]).to eq(:rsa)
+    end
+
+    it 'should fail if :private_key_type is neither :rsa nor :ec' do
+      jks = jks_resource.dup
+      jks[:private_key_type] = 'nosuchkeytype'
+
+      expect {
+        Puppet::Type.type(:java_ks).new(jks)
+      }.to raise_error(Puppet::Error)
     end
 
     it 'should fail if both :password and :password_file are provided' do


### PR DESCRIPTION
Add a new parameter "private_key_type" which defaults to "rsa" but can
also be set to "ec" for ECDSA keys.

Contains updated README and some spec tests for the type. Due to various
bugs in ruby-openssl it is currently difficult to properly test EC keys
(https://bugs.ruby-lang.org/issues/12348, https://github.com/ruby/openssl/issues/29).