### PR TITLE
Use password to decrypt PEM private key

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -13,9 +13,9 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
   def to_pkcs12(path)
     case private_key_type
     when :rsa
-      pkey = OpenSSL::PKey::RSA.new File.read private_key
+      pkey = OpenSSL::PKey::RSA.new File.read(private_key), get_password
     when :ec
-      pkey = OpenSSL::PKey::EC.new File.read private_key
+      pkey = OpenSSL::PKey::EC.new File.read(private_key), get_password
     end
 
     if chain


### PR DESCRIPTION
From README, java_ks should attempt to decrypt PEM private key suing the same password as the keystore itself.
Should work if PEM file is crypted or not.