### PR TITLE
(MODULES-2495): use password with encrypted private keys

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -13,9 +13,9 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
   def to_pkcs12(path)
     case private_key_type
     when :rsa
-      pkey = OpenSSL::PKey::RSA.new File.read private_key
+      pkey = OpenSSL::PKey::RSA.new File.read(private_key), get_password
     when :ec
-      pkey = OpenSSL::PKey::EC.new File.read private_key
+      pkey = OpenSSL::PKey::EC.new File.read(private_key), get_password
     end
 
     if chain

--- a/spec/unit/puppet/provider/java_ks/keytool_spec.rb
+++ b/spec/unit/puppet/provider/java_ks/keytool_spec.rb
@@ -83,7 +83,7 @@ describe Puppet::Type.type(:java_ks).provider(:keytool) do
         provider.stubs(:get_password).returns(resource[:password])
         File.stubs(:read).with(resource[:private_key]).returns('private key')
         File.stubs(:read).with(resource[:certificate]).returns(testing_ca.to_pem)
-        OpenSSL::PKey::RSA.expects(:new).with('private key').returns('priv_obj')
+        OpenSSL::PKey::RSA.expects(:new).with('private key', 'puppet').returns('priv_obj')
         OpenSSL::X509::Certificate.expects(:new).with(testing_ca.to_pem.chomp).returns('cert_obj')
 
         pkcs_double = BogusPkcs.new()


### PR DESCRIPTION
Small update to allow the provider to work with encrypted private keys. 

Unit test updated to pass, acceptance tests for encrypted private keys not included (ruby-openssl doesn't seem to provide direct option to create).