### PR TITLE
(maint) Change SHA256 fingerprint verification for certificates to SHA1

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ All parameters, except where specified, are optional.
 Takes intermediate certificate authorities from a separate file from the server certificate. This autorequires the file of the same path and must be present on the node before java_ks{} is run. Valid options: string. Default: undef.
 
 #####`ensure`
-Valid options: absent, present, latest. Latest verifies sha256 certificate fingerprints for the stored certificate and the source file. Default: present.
+Valid options: absent, present, latest. Latest verifies sha1 certificate fingerprints for the stored certificate and the source file. Default: present.
 
 #####`name`
 *Required.* Identifies the entry in the keystore. This will be converted to lowercase. Valid options: string. Default: undef.

--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -133,7 +133,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
           '-v', '-printcert', '-file', certificate
       ]
       output = run_command(cmd)
-      latest = output.scan(/SHA256:\s+(.*)/)[0][0]
+      latest = output.scan(/SHA1:\s+(.*)/)[0][0]
       return latest
     end
   end
@@ -154,7 +154,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
       tmpfile = password_file
       output = run_command(cmd, false, tmpfile)
       tmpfile.close!
-      current = output.scan(/Certificate fingerprints:\n\s+MD5:  .*\n\s+SHA1: .*\n\s+SHA256: (.*)/)[0][0]
+      current = output.scan(/Certificate fingerprints:\n\s+MD5:  .*\n\s+SHA1: (.*)/)[0][0]
       return current
     end
   end

--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -5,7 +5,7 @@ Puppet::Type.newtype(:java_ks) do
   ensurable do
 
     desc 'Has three states: present, absent, and latest.  Latest
-      will compare the on disk SHA256 fingerprint of the certificate to that
+      will compare the on disk SHA1 fingerprint of the certificate to that
       in keytool to determine if insync? returns true or false.  We redefine
       insync? for this paramerter to accomplish this.'
 

--- a/spec/unit/puppet/type/java_ks_spec.rb
+++ b/spec/unit/puppet/type/java_ks_spec.rb
@@ -137,11 +137,11 @@ describe Puppet::Type.type(:java_ks) do
   end
 
   describe 'when ensure is set to latest' do
-    it 'insync? should return false if sha256 fingerprints do not match and state is :present' do
+    it 'insync? should return false if sha1 fingerprints do not match and state is :present' do
       jks = jks_resource.dup
       jks[:ensure] = :latest
-      @provider.stubs(:latest).returns('7A:4A:0B:29:66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A:E7:8F:6A:AE:82:12:EE:3C:7C:C2:56:94:77')
-      @provider.stubs(:current).returns('10:84:17:2A:A5:23:15:82:1C:1E:72:5E:21:21:46:45:65:57:50:FE:2D:DA:7C:C8:57:D2:33:3A:B0:A6:7F:1C')
+      @provider.stubs(:latest).returns('9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A:E7:8F:6A')
+      @provider.stubs(:current).returns('21:46:45:65:57:50:FE:2D:DA:7C:C8:57:D2:33:3A:B0:A6')
       expect(Puppet::Type.type(:java_ks).new(jks).property(:ensure).insync?(:present)).to be_falsey
     end
 
@@ -151,11 +151,11 @@ describe Puppet::Type.type(:java_ks) do
       expect(Puppet::Type.type(:java_ks).new(jks).property(:ensure).insync?(:absent)).to be_falsey
     end
 
-    it 'insync? should return true if sha256 fingerprints match and state is :present' do
+    it 'insync? should return true if sha1 fingerprints match and state is :present' do
       jks = jks_resource.dup
       jks[:ensure] = :latest
-      @provider.stubs(:latest).returns('7A:4A:0B:29:66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A:E7:8F:6A:AE:82:12:EE:3C:7C:C2:56:94:77')
-      @provider.stubs(:current).returns('7A:4A:0B:29:66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A:E7:8F:6A:AE:82:12:EE:3C:7C:C2:56:94:77')
+      @provider.stubs(:latest).returns('66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A')
+      @provider.stubs(:current).returns('66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A')
       expect(Puppet::Type.type(:java_ks).new(jks).property(:ensure).insync?(:present)).to be_truthy
     end
   end


### PR DESCRIPTION
SHA256 fingerprints are not produced by older versions of keytool. This changes the use of SHA256 to SHA1 when verifying certificates by their fingerprint.