### PR TITLE
[MODULES-4505] Fix error: title patterns that use procs are not supported

### DIFF
--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -160,26 +160,25 @@ Puppet::Type.newtype(:java_ks) do
   # Our title_patterns method for mapping titles to namevars for supporting
   # composite namevars.
   def self.title_patterns
-    identity = lambda {|x| x}
     [
       [
         /^([^:]+)$/,
         [
-          [ :name, identity ]
+          [ :name ]
         ]
       ],
       [
         /^(.*):([a-z]:(\/|\\).*)$/i,
         [
-            [ :name, identity ],
-            [ :target, identity ]
+            [ :name ],
+            [ :target ]
         ]
       ],
       [
         /^(.*):(.*)$/,
         [
-          [ :name, identity ],
-          [ :target, identity ]
+          [ :name ],
+          [ :target ]
         ]
       ]
     ]


### PR DESCRIPTION
When running 'puppet generate types'