### PR TITLE
Modules 4605: add timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ Set the type of the private key. Usually this is RSA but EC (Elliptic Curve) key
 #####`trustcacerts`
 Certificate authorities input into a keystore aren’t trusted by default, so if you are adding a CA you need to set this parameter to 'true'. Valid options: 'true' or 'false'. Default: 'false'.
 
+#####`keytool_timeout`
+Timeout in seconds for all keytool commands. Default: 0 (no timeout is used).
+
+
 ### `storetype`
 
 The storetype parameter allows you to use 'jceks' format if desired.

--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -1,4 +1,5 @@
 require 'openssl'
+require 'timeout'
 require 'puppet/util/filetype'
 
 Puppet::Type.type(:java_ks).provide(:keytool) do
@@ -267,11 +268,15 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
     options = {:failonfail => true, :combine => true}
     output = if stdinfile
                withenv.call(env) do
-                 exec_method.call(cmd, options.merge(:stdinfile => stdinfile.path))
+               	 Timeout::timeout(@resource[:keytool_timeout]) {
+                 	exec_method.call(cmd, options.merge(:stdinfile => stdinfile.path))
+                 }
                end
              else
                withenv.call(env) do
-                 exec_method.call(cmd, options)
+                 Timeout::timeout(@resource[:keytool_timeout]) {
+                 	exec_method.call(cmd, options)
+                 }
                end
              end
 

--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -142,6 +142,12 @@ Puppet::Type.newtype(:java_ks) do
       }.flatten
     end
   end
+  
+  newparam(:keytool_timeout) do
+    desc "Timeout for the keytool command in seconds."
+
+    defaultto 0
+  end
 
   # Where we setup autorequires.
   autorequire(:file) do


### PR DESCRIPTION
#MODULES-4605

I added the timeout function to all commands which are executed. This function uses the new keytool_timeout parameter, which has the default value 0 => no timeout is used.