### PR TITLE
(PE-17635) Wrap keytool in timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Sets the type of the private key. Usually this is RSA but Elliptic Curve (EC) ke
 ##### `trustcacerts`
 Certificate authorities input into a keystore aren’t trusted by default, so if you are adding a CA you need to set this parameter to 'true'. Valid options: 'true' or 'false'. Default: 'false'.
 
+#####`keytool_timeout`
+Timeout in seconds for all keytool commands. Can be disabled by passing 0. Default: 120
+
 ##### `storetype`
 
 The storetype parameter allows you to use 'jceks' format if desired.

--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -143,6 +143,12 @@ Puppet::Type.newtype(:java_ks) do
     end
   end
 
+  newparam(:keytool_timeout) do
+    desc "Timeout for the keytool command in seconds."
+
+    defaultto 120
+  end
+
   # Where we setup autorequires.
   autorequire(:file) do
     auto_requires = []


### PR DESCRIPTION
Thanks to @MercateoITO in GH PR #176

The keytool may hang on occasion and block on IO in an unreproducable
case of the tempfile being removed before the keytool exits. We can wrap
the keytool execution in a timeout to handle this case such that it will
not eternally hang and block further puppet runs.