### PR TITLE
(MODULES-5357) Pin JDK installation pacakge to 8.0.144

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -105,7 +105,7 @@ RSpec.configure do |c|
     pp = <<-EOS
 include chocolatey
 package { 'jdk8':
-  ensure   => installed,
+  ensure   => '8.0.144',
   provider => 'chocolatey'
 }
     EOS
@@ -123,7 +123,7 @@ end
 
 RSpec.shared_context 'common variables' do
   before {
-    java_major, java_minor = (ENV['JAVA_VERSION'] || '8u131').split('u')
+    java_major, java_minor = (ENV['JAVA_VERSION'] || '8u144').split('u')
     @ensure_ks = 'latest'
     @resource_path = "undef"
     @target_dir = '/etc/'


### PR DESCRIPTION
Previously the acceptance tests installed JDK from the chocolatey pacakge repo
however the version of the installed pacakges was not enforced and the
calculation for the Java path then fails as it is expected java 8u131.  This
commit pins the JDK8 pacakged to the latest 8u141 in the chocolatey repo and
updates the java version logic with the new version number.