### PR TITLE
Make it possible to refresh java keystore

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -9,6 +9,8 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
     'keytool'
   end
 
+  has_feature :refreshable
+
   # Keytool can only import a keystore if the format is pkcs12.  Generating and
   # importing a keystore is used to add private_key and certifcate pairs.
   def to_pkcs12(path)

--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -2,6 +2,9 @@ Puppet::Type.newtype(:java_ks) do
   @doc = 'Manages the entries in a java keystore, and uses composite namevars to
   accomplish the same alias spread across multiple target keystores.'
 
+  feature :refreshable, "The provider can refresh the keystore",
+    :methods => [:update]
+
   ensurable do
 
     desc 'Has three states: present, absent, and latest.  Latest
@@ -171,6 +174,10 @@ Puppet::Type.newtype(:java_ks) do
       auto_requires << ::File.dirname(@parameters[:target].value)
     end
     auto_requires
+  end
+
+  def refresh
+    provider.update
   end
 
   # Our title_patterns method for mapping titles to namevars for supporting


### PR DESCRIPTION
[MODULES-1997](https://tickets.puppetlabs.com/browse/MODULES-1997) was opened because someone was unable to make the certificate inside the java keystore update. We did this internally by making the module refreshable. 

If there's something I'm missing or a better way to make this pull request please let me know.