### PR TITLE
Add Java 9 support

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -161,7 +161,11 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
       tmpfile = password_file
       output = run_command(cmd, false, tmpfile)
       tmpfile.close!
-      current = output.scan(/Certificate fingerprints:\n\s+MD5:  .*\n\s+SHA1: (.*)/)[0][0]
+      if output.include? 'MD5:'
+        current = output.scan(/Certificate fingerprints:\n\s+MD5:  .*\n\s+SHA1: (.*)/)[0][0]
+      else
+        current = output.scan(/Certificate fingerprints:\n\s+SHA1: (.*)/)[0][0]
+      end
       return current
     end
   end


### PR DESCRIPTION
In the current-method the module uses the output from the verbose output of keytool. In Java 8 this output was similar to:
```
...
Certificate fingerprints:
         MD5:  8H:89:26:BA:5C:04:D8:CC:D0:1B:85:50:2E:38:14:1F
         SHA1: DE:F2:8D:BE:D5:47:CD:F3:D5:2B:62:7F:41:63:7C:44:30:42:FE:13
         SHA256: 19:DD:8A:4B:0F:47:4A:15:CD:EF:7A:41:C5:98:A2:10:FA:90:5F:4B:8F:F4:08:04:CE:A5:52:9F:47:E7:CF:30
         Signature algorithm name: MD5withRSA
         Version: 1
...
```
While when using Java 9 this output is:
```
...
Certificate fingerprints:
         SHA1: DE:F2:8D:BE:D5:47:CD:F3:D5:2B:62:7F:41:63:7C:44:30:42:FE:13
         SHA256: 19:DD:8A:4B:0F:47:4A:15:CD:EF:7A:41:C5:98:A2:10:FA:90:5F:4B:8F:F4:08:04:CE:A5:52:9F:47:E7:CF:30
...
```
This change in Java 9 makes the java_ks resource break checking if the keystore is correct. This pull request will fix this.