### PR TITLE
Update metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,6 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "10 SP4",
         "11 SP1",
         "12"
       ]
@@ -55,9 +54,9 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
@@ -84,7 +83,6 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "Server 2003 R2",
         "Server 2008 R2",
         "Server 2012",
         "Server 2012 R2",


### PR DESCRIPTION
This includes the removal of Sles 10, Debian 6 and Windows 2003.
Debian 9 has been added. These changes are according to https://puppet.com/docs/pe/2017.3/installing/supported_operating_systems.html.