### PR TITLE
(maint) - Updating flag to stop appveyor config from being deleted

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,3 @@
 ---
 appveyor.yml:
-  delete: true
+  delete: false


### PR DESCRIPTION
Planning on putting java_ks under windows management in modulesync.
Therefore I want to keep the appveyor file to run tests against Windows
on every merge.