### PR TITLE
Add support for specifying a source cert alias

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -103,6 +103,13 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
         '-srckeystore', certificate
     ]
 
+    if @resource[:source_alias]
+      cmd.concat([
+        '-srcalias', @resource[:source_alias],
+        '-destalias', @resource[:name]
+      ])
+    end
+
     pwfile = password_file
     run_command(cmd, @resource[:target], pwfile)
     pwfile.close! if pwfile.is_a? Tempfile

--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -161,6 +161,10 @@ Puppet::Type.newtype(:java_ks) do
     desc "The source keystore password"
   end
 
+  newparam(:source_alias) do
+    desc "The source certificate alias"
+  end
+
   # Where we setup autorequires.
   autorequire(:file) do
     auto_requires = []

--- a/spec/acceptance/pkcs12_spec.rb
+++ b/spec/acceptance/pkcs12_spec.rb
@@ -5,35 +5,74 @@ hostname = default.node_name
 # SLES by default does not support this form of encyrption.
 describe 'managing java pkcs12', :unless => (UNSUPPORTED_PLATFORMS.include?(fact('operatingsystem')) || fact('operatingsystem') == 'SLES') do
   include_context 'common variables'
-  case fact('osfamily')
-    when 'windows'
-      target = 'c:/pkcs12.ks'
-    else
-      target = '/etc/pkcs12.ks'
-  end
-
-  it 'creates a private key with chain' do
-    pp = <<-EOS
-      java_ks { 'Leaf Cert:#{target}':
-        ensure          => #{@ensure_ks},
-        certificate     => "#{@temp_dir}leaf.p12",
-        storetype       => 'pkcs12',
-        password        => 'puppet',
-        path            => #{@resource_path},
-        source_password => 'pkcs12pass'
-      }
-    EOS
-
-    apply_manifest(pp, :catch_failures => true)
-  end
-
-  it 'verifies the private key and chain' do
-    shell("\"#{@keytool_path}keytool\" -list -v -keystore #{target} -storepass puppet") do |r|
-      expect(r.exit_code).to be_zero
-      expect(r.stdout).to match(/Alias name: leaf cert/)
-      expect(r.stdout).to match(/Entry type: (keyEntry|PrivateKeyEntry)/)
-      expect(r.stdout).to match(/Certificate chain length: 3/)
-      expect(r.stdout).to match(/^Serial number: 5$.*^Serial number: 4$.*^Serial number: 3$/m)
+  context 'with defaults' do
+    case fact('osfamily')
+      when 'windows'
+        target = 'c:/pkcs12.ks'
+      else
+        target = '/etc/pkcs12.ks'
     end
-  end
+
+    it 'creates a private key with chain' do
+      pp = <<-EOS
+        java_ks { 'Leaf Cert:#{target}':
+          ensure          => #{@ensure_ks},
+          certificate     => "#{@temp_dir}leaf.p12",
+          storetype       => 'pkcs12',
+          password        => 'puppet',
+          path            => #{@resource_path},
+          source_password => 'pkcs12pass'
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    it 'verifies the private key and chain' do
+      shell("\"#{@keytool_path}keytool\" -list -v -keystore #{target} -storepass puppet") do |r|
+        expect(r.exit_code).to be_zero
+        expect(r.stdout).to match(/Alias name: leaf cert/)
+        expect(r.stdout).to match(/Entry type: (keyEntry|PrivateKeyEntry)/)
+        expect(r.stdout).to match(/Certificate chain length: 3/)
+        expect(r.stdout).to match(/^Serial number: 5$.*^Serial number: 4$.*^Serial number: 3$/m)
+      end
+    end
+  end # context 'with defaults'
+
+  context 'with a different alias' do
+    case fact('osfamily')
+      when 'windows'
+        target = 'c:/pkcs12-2.ks'
+      else
+        target = '/etc/pkcs12-2.ks'
+    end
+
+    it 'creates a private key with chain' do
+      pp = <<-EOS
+        java_ks { 'Leaf_Cert:#{target}':
+          ensure          => #{@ensure_ks},
+          certificate     => "#{@temp_dir}leaf.p12",
+          storetype       => 'pkcs12',
+          password        => 'puppet',
+          path            => #{@resource_path},
+          source_password => 'pkcs12pass',
+          source_alias    => 'Leaf Cert'
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    it 'verifies the private key and chain' do
+      shell("\"#{@keytool_path}keytool\" -list -v -keystore #{target} -storepass puppet") do |r|
+        expect(r.exit_code).to be_zero
+        expect(r.stdout).to match(/Alias name: leaf_cert/)
+        expect(r.stdout).to match(/Entry type: (keyEntry|PrivateKeyEntry)/)
+        expect(r.stdout).to match(/Certificate chain length: 3/)
+        expect(r.stdout).to match(/^Serial number: 5$.*^Serial number: 4$.*^Serial number: 3$/m)
+      end
+    end
+  end # context 'with a different alias'
 end


### PR DESCRIPTION
This is useful in scenarios where the source alias is different from import alias.
Added test case to exercise.