### PR TITLE
Add support for 'destkeypass' when importing PKCS12 keystores.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,10 @@ This password is used to protect the keystore. If private keys are also protecte
 Sets a plaintext file where the password is stored. Used as an alternative to `password`. This cannot be used together with `password`, but *you must pass at least one of these parameters.* Valid options: String to the plaintext file. Default: undef.
 
 #### `password_fail_reset`
-
 If the supplied password does not succeed in unlocking the keystore file, then **delete** the keystore file and create a new one. Default: `false`
 
 ##### `destkeypass`
-The password you want to set to protect the key in the keystore.
+The password you want to set to protect the key in the keystore. Can be used with `pkcs12` stores to change the source password.
 
 ##### `path`
 Used for command (keytool, openssl) execution. Valid options: array or file path separated list (for example : in linux). Default: undef.
@@ -125,7 +124,6 @@ Used for command (keytool, openssl) execution. Valid options: array or file path
 Sets a private key that encrypts traffic to a server application. Must be accompanied by a signed certificate for the keytool provider. This autorequires the specified file and must be present on the node before java_ks{} is run. Valid options: string. Default: undef.
 
 ##### `private_key_type`
-
 Sets the type of the private key. Usually this is RSA but Elliptic Curve (EC) keys are also supported. Valid options: `rsa` and `ec`. Default: `rsa`.
 
 ##### `target`
@@ -138,8 +136,7 @@ Certificate authorities input into a keystore aren’t trusted by default, so if
 Timeout in seconds for all keytool commands. Can be disabled by passing 0. Default: 120
 
 ##### `storetype`
-
-The storetype parameter allows you to use 'jceks' format if desired.
+The storetype parameter allows you to use 'jceks' or 'pkcs12' format certificates if desired.
 
 ```puppet
 java_ks { 'puppetca:/opt/puppet/truststore.jceks':
@@ -150,6 +147,12 @@ java_ks { 'puppetca:/opt/puppet/truststore.jceks':
   trustcacerts => true,
 }
 ```
+
+##### `source_alias`
+The source certificate alias to import. Only supported by `pkcs12` certs.
+
+##### `source_password`
+The source keystore password. Required if using `storetype => pkcs12`.
 
 ## Limitations
 

--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -110,8 +110,8 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
 
     if @resource[:destkeypass]
       cmd.concat([
-        '-destkeypass', @resource[:destkeypass]
-      ])
+                   '-destkeypass', @resource[:destkeypass]
+                 ])
     end
 
     pwfile = password_file

--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -108,6 +108,12 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
                  ])
     end
 
+    if @resource[:destkeypass]
+      cmd.concat([
+        '-destkeypass', @resource[:destkeypass]
+      ])
+    end
+
     pwfile = password_file
     run_command(cmd, @resource[:target], pwfile)
     pwfile.close! if pwfile.is_a? Tempfile

--- a/spec/acceptance/pkcs12_spec.rb
+++ b/spec/acceptance/pkcs12_spec.rb
@@ -143,5 +143,4 @@ describe 'managing java pkcs12', unless: (UNSUPPORTED_PLATFORMS.include?(fact('o
       end
     end
   end # context 'with a destkeypass'
-
 end

--- a/spec/acceptance/pkcs12_spec.rb
+++ b/spec/acceptance/pkcs12_spec.rb
@@ -92,4 +92,56 @@ describe 'managing java pkcs12', unless: (UNSUPPORTED_PLATFORMS.include?(fact('o
       end
     end
   end # context 'with a different alias'
+
+  context 'with a destkeypass' do
+    target = case fact('osfamily')
+             when 'windows'
+               'c:/pkcs12-3.ks'
+             else
+               '/etc/pkcs12-3.ks'
+             end
+
+    it 'creates a private key with chain' do # rubocop:disable RSpec/ExampleLength : Variable assignments must be within 'it do'
+      pp = <<-MANIFEST
+        java_ks { 'Leaf_Cert:#{target}':
+          ensure          => #{@ensure_ks},
+          certificate     => "#{@temp_dir}leaf.p12",
+          destkeypass     => "abcdef123456",
+          storetype       => 'pkcs12',
+          password        => 'puppet',
+          path            => #{@resource_path},
+          source_password => 'pkcs12pass',
+          source_alias    => 'Leaf Cert'
+        }
+      MANIFEST
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    expectations = [
+      %r{Alias name: leaf_cert},
+      %r{Entry type: (keyEntry|PrivateKeyEntry)},
+      %r{Certificate chain length: 3},
+      %r{^Serial number: 5$.*^Serial number: 4$.*^Serial number: 3$}m,
+    ]
+    it 'verifies the private key and chain #zero' do
+      shell("\"#{@keytool_path}keytool\" -list -v -keystore #{target} -storepass puppet") do |r|
+        expect(r.exit_code).to be_zero
+      end
+    end
+    it 'verifies the private key and chain #expected' do
+      shell("\"#{@keytool_path}keytool\" -list -v -keystore #{target} -storepass puppet") do |r|
+        expectations.each do |expect|
+          expect(r.stdout).to match(expect)
+        end
+      end
+    end
+    it 'verifies the private key password' do
+      shell("\"#{@keytool_path}keytool\" -keypasswd -keystore #{target} -storepass puppet -alias leaf_cert -keypass abcdef123456 -new pass1234") do |r|
+        expect(r.exit_code).to be_zero
+      end
+    end
+  end # context 'with a destkeypass'
+
 end


### PR DESCRIPTION
Currently, 'destkeypass' can be used to specify the key password required within the keystore. 

However this is ignored by the PKCS12 import, and instead the original PKCS12 key password is retained. 
Update behaviour to specify `-destkeypass [destkeypass]` if supplied.

Add acceptance test to cover.