### PR TITLE
(MODULES-6918) update jdk version in spec_helper_acceptance

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -108,7 +108,7 @@ RSpec.configure do |c|
         pp_one = <<-MANIFEST
 include chocolatey
 package { 'jdk8':
-  ensure   => '8.0.162',
+  ensure   => '8.0.172',
   provider => 'chocolatey'
 }
     MANIFEST


### PR DESCRIPTION
This fixes the jdk 8.0.162 installation issue we were seeing. Not sure
what the cause of the problem was but we weren't the only ones having
the issue: https://chocolatey.org/packages/jdk8/8.0.162 . 8.0.172 is now
trusted by chocolately so updating did not seem like a big deal.