### PR TITLE
(MODULES-6342) Update pathing for new java in #229

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -127,7 +127,7 @@ end
 
 RSpec.shared_context 'common variables' do
   before(:each) do
-    java_major, java_minor = (ENV['JAVA_VERSION'] || '8u162').split('u')
+    java_major, java_minor = (ENV['JAVA_VERSION'] || '8u172').split('u')
     @ensure_ks = 'latest'
     @resource_path = 'undef'
     @target_dir = '/etc/'


### PR DESCRIPTION
Windows is failing on this. Version was bumped from 162 to 172 in #229 but the path wasn't changed.