### PR TITLE
(FM-7277) Fix incorrect reference

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -145,7 +145,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
       '-keystore', @resource[:target],
       '-alias', @resource[:name]
     ]
-    cmd += ['-storetype', storetype] if storetype == 'jceks'
+    cmd += ['-storetype', storetype] if storetype == :jceks
     begin
       tmpfile = password_file
       run_command(cmd, false, tmpfile)


### PR DESCRIPTION
This fix updates the provider to test a Symbol, not a String.
Without this fix the provider can never list the contents of a 'jceks'
store.