### PR TITLE
pdksync - (MODULES-7658) use beaker3 in puppet-module-gems

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -19,17 +19,6 @@ Gemfile:
           - mswin
           - mingw
           - x64_mingw
-      - gem: beaker
-        version: '~> 3.13'
-        from_env: BEAKER_VERSION
-      - gem: beaker-abs
-        from_env: BEAKER_ABS_VERSION
-        version: '~> 0.1'
-      - gem: beaker-pe
-      - gem: beaker-hostgenerator
-        from_env: BEAKER_HOSTGENERATOR_VERSION
-      - gem: beaker-rspec
-        from_env: BEAKER_RSPEC_VERSION
 
 .rubocop.yml:
   default_configs:

--- a/Gemfile
+++ b/Gemfile
@@ -37,11 +37,6 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}",                            require: false, platforms: [:ruby]
   gem "puppet-module-win-system-r#{minor_version}",                              require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.13')
-  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
-  gem "beaker-pe",                                                               require: false
-  gem "beaker-hostgenerator"
-  gem "beaker-rspec"
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
(MODULES-7658) use beaker3 in puppet-module-gems
pdk version: `1.5.0` 
