### PR TITLE
(FM-7505) - Bumping Windows jdk version to 8.0.191

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -123,7 +123,7 @@ RSpec.configure do |c|
         pp_one = <<-MANIFEST
 include chocolatey
 package { 'jdk8':
-  ensure   => '8.0.181',
+  ensure   => '8.0.191',
   provider => 'chocolatey'
 }
     MANIFEST
@@ -142,7 +142,7 @@ end
 
 RSpec.shared_context 'common variables' do
   before(:each) do
-    java_major, java_minor = (ENV['JAVA_VERSION'] || '8u181').split('u')
+    java_major, java_minor = (ENV['JAVA_VERSION'] || '8u191').split('u')
     @ensure_ks = 'latest'
     @resource_path = 'undef'
     @target_dir = '/etc/'


### PR DESCRIPTION
Windows tests are failing as a new version of the java jdk is released.
Bumping the version in the spec_helper_acceptance.rb to include the
latest version.