### PR TITLE
Fix provider so "latest" gets the MD5 AND SHA1 hashes for comparing

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -188,7 +188,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
         '-v', '-printcert', '-file', certificate
       ]
       output = run_command(cmd)
-      latest = output.scan(%r{SHA1:\s+(.*)})[0][0]
+      latest = extract_fingerprint(output)
       latest
     end
   end


### PR DESCRIPTION
The `current` function uses the `extract_fingerprint` function which pulls out both the MD5 and SHA1 fingerprints. Whereas the `latest` function just does a `scan` to pull out the SHA1 fingerprint for non-`pkcs12` storetypes

This change fixes `latest` to use the same `extract_fingerprint` function for comparison. Without this, PEM formatted certs and keys would always deleted and re-added to the keystore for every run.