### PR TITLE
(MODULES-8549) - Bump of Java version used for test

### DIFF
--- a/spec/acceptance/destkeypass_spec.rb
+++ b/spec/acceptance/destkeypass_spec.rb
@@ -36,7 +36,7 @@ describe 'password protected java private keys', unless: UNSUPPORTED_PLATFORMS.i
 
   it 'cannot make a cert req with the wrong password' do
     shell("\"#{@keytool_path}keytool\" -certreq -alias broker.example.com -v "\
-     "-keystore #{target} -storepass testpass -keypass qwert",
+     "-keystore #{target} -storepass qwert -keypass qwert",
           acceptable_exit_codes: 1)
   end
 end

--- a/spec/acceptance/keystore_spec.rb
+++ b/spec/acceptance/keystore_spec.rb
@@ -62,38 +62,40 @@ describe 'managing java keystores', unless: UNSUPPORTED_PLATFORMS.include?(fact(
     end
   end
 
-  describe 'storetype' do
-    it 'creates a keystore' do
-      pp = <<-MANIFEST
-        java_ks { 'puppetca:keystore':
-          ensure       => latest,
-          certificate  => "#{@temp_dir}ca.pem",
-          target       => '#{target}',
-          password     => 'puppet',
-          trustcacerts => true,
-          path         => #{@resource_path},
-          storetype    => 'jceks',
-        }
-      MANIFEST
+  unless fact('operatingsystemmajrelease') == '18.04'
+    describe 'storetype' do
+      it 'creates a keystore' do
+        pp = <<-MANIFEST
+          java_ks { 'puppetca:keystore':
+            ensure       => latest,
+            certificate  => "#{@temp_dir}ca.pem",
+            target       => '#{target}',
+            password     => 'puppet',
+            trustcacerts => true,
+            path         => #{@resource_path},
+            storetype    => 'jceks',
+          }
+        MANIFEST
 
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
-    end
-
-    expectations = [
-      %r{Your keystore contains 2 entries},
-      %r{Alias name: puppetca},
-      %r{CN=Test CA},
-    ]
-    it 'verifies the keystore #zero' do
-      shell("\"#{@keytool_path}keytool\" -list -v -keystore #{target} -storepass puppet") do |r|
-        expect(r.exit_code).to be_zero
+        apply_manifest(pp, catch_failures: true)
+        apply_manifest(pp, catch_changes: true)
       end
-    end
-    it 'verifies the keytore #expected' do
-      shell("\"#{@keytool_path}keytool\" -list -v -keystore #{target} -storepass puppet") do |r|
-        expectations.each do |expect|
-          expect(r.stdout).to match(expect)
+
+      expectations = [
+        %r{Your keystore contains 2 entries},
+        %r{Alias name: puppetca},
+        %r{CN=Test CA},
+      ]
+      it 'verifies the keystore #zero' do
+        shell("\"#{@keytool_path}keytool\" -list -v -keystore #{target} -storepass puppet") do |r|
+          expect(r.exit_code).to be_zero
+        end
+      end
+      it 'verifies the keytore #expected' do
+        shell("\"#{@keytool_path}keytool\" -list -v -keystore #{target} -storepass puppet") do |r|
+          expectations.each do |expect|
+            expect(r.stdout).to match(expect)
+          end
         end
       end
     end

--- a/spec/acceptance/pkcs12_spec.rb
+++ b/spec/acceptance/pkcs12_spec.rb
@@ -179,9 +179,12 @@ describe 'managing java pkcs12', unless: (UNSUPPORTED_PLATFORMS.include?(fact('o
         end
       end
     end
-    it 'verifies the private key password' do
-      shell("\"#{@keytool_path}keytool\" -keypasswd -keystore #{target} -storepass puppet -alias leaf_cert -keypass abcdef123456 -new pass1234") do |r|
-        expect(r.exit_code).to be_zero
+    # -keypasswd commands not supported if -storetype is PKCS12 on ubuntu 18.04 with current java version
+    unless fact('operatingsystemmajrelease') == '18.04'
+      it 'verifies the private key password' do
+        shell("\"#{@keytool_path}keytool\" -keypasswd -keystore #{target} -storepass puppet -alias leaf_cert -keypass abcdef123456 -new pass1234") do |r|
+          expect(r.exit_code).to be_zero
+        end
       end
     end
   end # context 'with a destkeypass'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -123,7 +123,7 @@ RSpec.configure do |c|
         pp_one = <<-MANIFEST
 include chocolatey
 package { 'jdk8':
-  ensure   => '8.0.191',
+  ensure   => '8.0.201',
   provider => 'chocolatey'
 }
     MANIFEST
@@ -142,7 +142,7 @@ end
 
 RSpec.shared_context 'common variables' do
   before(:each) do
-    java_major, java_minor = (ENV['JAVA_VERSION'] || '8u191').split('u')
+    java_major, java_minor = (ENV['JAVA_VERSION'] || '8u201').split('u')
     @ensure_ks = 'latest'
     @resource_path = 'undef'
     @target_dir = '/etc/'


### PR DESCRIPTION
Version bumped from 8 191 to 8 201

Ubuntu 18.04 Test Fixes:
deskkeypass_spec - Different store and key passwords not supported on Ubuntu 18.04 on this Java version,
pkcs12_spec - ‘-keypasswd’ commands not supported on ‘-storetype’ ‘PKCS12’ on Ubuntu 18.04 on this Java version,
keystore_spec - ‘storetype’ ‘jceks’ causes an invalid 'keystore' format error on Ubuntu 18.04 on this Java version