### PR TITLE
(MODULES-3958) - Utilize rspec-mock and add code coverage

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,1 @@
+--relative

--- a/.sync.yml
+++ b/.sync.yml
@@ -3,6 +3,13 @@
   required:
     - ---.project
 
+.gitlab-ci.yml:
+  unmanaged: true
+
+.rubocop.yml:
+  default_configs:
+    inherit_from: .rubocop_todo.yml
+
 .travis.yml:
   docker_sets:
     - set: docker/centos-7
@@ -13,6 +20,9 @@
   branches:
     - release
  
+appveyor.yml:
+  spec_type: spec
+
 Gemfile:
   required:
     ':system_tests':
@@ -30,12 +40,6 @@ Gemfile:
         ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
         condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
 
-.rubocop.yml:
-  default_configs:
-    inherit_from: .rubocop_todo.yml
-
-.gitlab-ci.yml:
-  unmanaged: true
-
-appveyor.yml:
-  spec_type: spec
+spec/spec_helper.rb:
+  mock_with: ':rspec'
+  coverage_report: true

--- a/metadata.json
+++ b/metadata.json
@@ -100,5 +100,5 @@
   "description": "Uses a combination of keytool and Ruby openssl library to manage entries in a Java keystore.",
   "template-url": "https://github.com/puppetlabs/pdk-templates",
   "template-ref": "heads/master-0-gfde5699",
-  "pdk-version": "1.8.0"
+  "pdk-version": "1.9.0"
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
+
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 
@@ -34,6 +38,7 @@ RSpec.configure do |c|
   end
   c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
   c.after(:suite) do
+    RSpec::Puppet::Coverage.report!(0)
   end
 end
 

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,0 +1,28 @@
+if ENV['COVERAGE'] == 'yes'
+  require 'simplecov'
+  require 'simplecov-console'
+  require 'codecov'
+
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::Console,
+    SimpleCov::Formatter::Codecov,
+  ]
+  SimpleCov.start do
+    track_files 'lib/**/*.rb'
+
+    add_filter '/spec'
+
+    # do not track vendored files
+    add_filter '/vendor'
+    add_filter '/.vendor'
+
+    # do not track gitignored files
+    # this adds about 4 seconds to the coverage check
+    # this could definitely be optimized
+    add_filter do |f|
+      # system returns true if exit status is 0, which with git-check-ignore means file is ignored
+      system("git check-ignore --quiet #{f.filename}")
+    end
+  end
+end

--- a/spec/unit/puppet/type/java_ks_spec.rb
+++ b/spec/unit/puppet/type/java_ks_spec.rb
@@ -9,7 +9,7 @@ describe Puppet::Type.type(:java_ks) do
       '/tmp/'
     end
   end
-  let(:provider_var) { stub('provider', class: Puppet::Type.type(:java_ks).defaultprovider, clear: nil) }
+  let(:provider_var) { class_double('provider', class: described_class.defaultprovider, clear: nil) }
   let(:app_example_com) do
     {
       title: "app.example.com:#{temp_dir}application.jks",
@@ -29,23 +29,23 @@ describe Puppet::Type.type(:java_ks) do
   end
 
   before(:each) do
-    Puppet::Type.type(:java_ks).defaultprovider.stubs(:new).returns(provider_var)
+    allow(described_class.defaultprovider).to receive(:new).and_return(provider_var)
   end
 
   it 'defaults to being present' do
-    expect(Puppet::Type.type(:java_ks).new(app_example_com)[:ensure]).to eq(:present)
+    expect(described_class.new(app_example_com)[:ensure]).to eq(:present)
   end
 
   describe 'when validating attributes' do
     [:name, :target, :private_key, :private_key_type, :certificate, :password, :password_file, :trustcacerts, :destkeypass, :password_fail_reset, :source_password].each do |param|
       it "should have a #{param} parameter" do
-        expect(Puppet::Type.type(:java_ks).attrtype(param)).to eq(:param)
+        expect(described_class.attrtype(param)).to eq(:param)
       end
     end
 
     [:ensure].each do |prop|
       it "should have a #{prop} property" do
-        expect(Puppet::Type.type(:java_ks).attrtype(prop)).to eq(:property)
+        expect(described_class.attrtype(prop)).to eq(:property)
       end
     end
   end
@@ -53,58 +53,58 @@ describe Puppet::Type.type(:java_ks) do
   describe 'when validating attribute values' do
     [:present, :absent, :latest].each do |value|
       it "should support #{value} as a value to ensure" do
-        Puppet::Type.type(:java_ks).new(jks_resource.merge(ensure: value))
+        described_class.new(jks_resource.merge(ensure: value))
       end
     end
 
     it 'first half of title should map to name parameter' do
       jks = jks_resource.dup
       jks.delete(:name)
-      expect(Puppet::Type.type(:java_ks).new(jks)[:name]).to eq(jks_resource[:name])
+      expect(described_class.new(jks)[:name]).to eq(jks_resource[:name])
     end
 
     it 'second half of title should map to target parameter when no target is supplied' do
       jks = jks_resource.dup
       jks.delete(:target)
-      expect(Puppet::Type.type(:java_ks).new(jks)[:target]).to eq(jks_resource[:target])
+      expect(described_class.new(jks)[:target]).to eq(jks_resource[:target])
     end
 
     it 'second half of title should not map to target parameter when target is supplied #not to equal' do
       jks = jks_resource.dup
       jks[:target] = "#{temp_dir}some_other_app.jks"
-      expect(Puppet::Type.type(:java_ks).new(jks)[:target]).not_to eq(jks_resource[:target])
+      expect(described_class.new(jks)[:target]).not_to eq(jks_resource[:target])
     end
     it 'second half of title should not map to target parameter when target is supplied #to equal' do
       jks = jks_resource.dup
       jks[:target] = "#{temp_dir}some_other_app.jks"
-      expect(Puppet::Type.type(:java_ks).new(jks)[:target]).to eq("#{temp_dir}some_other_app.jks")
+      expect(described_class.new(jks)[:target]).to eq("#{temp_dir}some_other_app.jks")
     end
 
     it 'title components should map to namevar parameters #name' do
       jks = jks_resource.dup
       jks.delete(:name)
       jks.delete(:target)
-      expect(Puppet::Type.type(:java_ks).new(jks)[:name]).to eq(jks_resource[:name])
+      expect(described_class.new(jks)[:name]).to eq(jks_resource[:name])
     end
     it 'title components should map to namevar parameters #target' do
       jks = jks_resource.dup
       jks.delete(:name)
       jks.delete(:target)
-      expect(Puppet::Type.type(:java_ks).new(jks)[:target]).to eq(jks_resource[:target])
+      expect(described_class.new(jks)[:target]).to eq(jks_resource[:target])
     end
 
     it 'downcases :name values' do
       jks = jks_resource.dup
       jks[:name] = 'APP.EXAMPLE.COM'
-      expect(Puppet::Type.type(:java_ks).new(jks)[:name]).to eq(jks_resource[:name])
+      expect(described_class.new(jks)[:name]).to eq(jks_resource[:name])
     end
 
     it 'has :false value to :trustcacerts when parameter not provided' do
-      expect(Puppet::Type.type(:java_ks).new(jks_resource)[:trustcacerts]).to eq(:false)
+      expect(described_class.new(jks_resource)[:trustcacerts]).to eq(:false)
     end
 
     it 'has :rsa as the default value for :private_key_type' do
-      expect(Puppet::Type.type(:java_ks).new(jks_resource)[:private_key_type]).to eq(:rsa)
+      expect(described_class.new(jks_resource)[:private_key_type]).to eq(:rsa)
     end
 
     it 'fails if :private_key_type is neither :rsa nor :ec' do
@@ -112,7 +112,7 @@ describe Puppet::Type.type(:java_ks) do
       jks[:private_key_type] = 'nosuchkeytype'
 
       expect {
-        Puppet::Type.type(:java_ks).new(jks)
+        described_class.new(jks)
       }.to raise_error(Puppet::Error)
     end
 
@@ -120,7 +120,7 @@ describe Puppet::Type.type(:java_ks) do
       jks = jks_resource.dup
       jks[:password_file] = '/path/to/password_file'
       expect {
-        Puppet::Type.type(:java_ks).new(jks)
+        described_class.new(jks)
       }.to raise_error(Puppet::Error, %r{You must pass either})
     end
 
@@ -128,7 +128,7 @@ describe Puppet::Type.type(:java_ks) do
       jks = jks_resource.dup
       jks.delete(:password)
       expect {
-        Puppet::Type.type(:java_ks).new(jks)
+        described_class.new(jks)
       }.to raise_error(Puppet::Error, %r{You must pass one of})
     end
 
@@ -136,7 +136,7 @@ describe Puppet::Type.type(:java_ks) do
       jks = jks_resource.dup
       jks[:password] = 'aoeui'
       expect {
-        Puppet::Type.type(:java_ks).new(jks)
+        described_class.new(jks)
       }.to raise_error(Puppet::Error, %r{6 characters})
     end
 
@@ -144,19 +144,19 @@ describe Puppet::Type.type(:java_ks) do
       jks = jks_resource.dup
       jks[:destkeypass] = 'aoeui'
       expect {
-        Puppet::Type.type(:java_ks).new(jks)
+        described_class.new(jks)
       }.to raise_error(Puppet::Error, %r{length 6})
     end
 
     it 'has :false value to :password_fail_reset when parameter not provided' do
-      expect(Puppet::Type.type(:java_ks).new(jks_resource)[:password_fail_reset]).to eq(:false)
+      expect(described_class.new(jks_resource)[:password_fail_reset]).to eq(:false)
     end
 
     it 'fails if :source_password is not provided for pkcs12 :storetype' do
       jks = jks_resource.dup
       jks[:storetype] = 'pkcs12'
       expect {
-        Puppet::Type.type(:java_ks).new(jks)
+        described_class.new(jks)
       }.to raise_error(Puppet::Error, %r{You must provide 'source_password' when using a 'pkcs12' storetype})
     end
   end
@@ -165,36 +165,36 @@ describe Puppet::Type.type(:java_ks) do
     it 'insync? should return false if sha1 fingerprints do not match and state is :present' do
       jks = jks_resource.dup
       jks[:ensure] = :latest
-      provider_var.stubs(:latest).returns('9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A:E7:8F:6A')
-      provider_var.stubs(:current).returns('21:46:45:65:57:50:FE:2D:DA:7C:C8:57:D2:33:3A:B0:A6')
-      expect(Puppet::Type.type(:java_ks).new(jks).property(:ensure)).not_to be_insync(:present)
+      allow(provider_var).to receive(:latest).and_return('9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A:E7:8F:6A')
+      allow(provider_var).to receive(:current).and_return('21:46:45:65:57:50:FE:2D:DA:7C:C8:57:D2:33:3A:B0:A6')
+      expect(described_class.new(jks).property(:ensure)).not_to be_insync(:present)
     end
 
     it 'insync? should return false if state is :absent' do
       jks = jks_resource.dup
       jks[:ensure] = :latest
-      expect(Puppet::Type.type(:java_ks).new(jks).property(:ensure)).not_to be_insync(:absent)
+      expect(described_class.new(jks).property(:ensure)).not_to be_insync(:absent)
     end
 
     it 'insync? should return true if sha1 fingerprints match and state is :present' do
       jks = jks_resource.dup
       jks[:ensure] = :latest
-      provider_var.stubs(:latest).returns('66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A')
-      provider_var.stubs(:current).returns('66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A')
-      expect(Puppet::Type.type(:java_ks).new(jks).property(:ensure)).to be_insync(:present)
+      allow(provider_var).to receive(:latest).and_return('66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A')
+      allow(provider_var).to receive(:current).and_return('66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A')
+      expect(described_class.new(jks).property(:ensure)).to be_insync(:present)
     end
   end
 
   describe 'when file resources are in the catalog' do
-    let(:file_provider) { stub('provider', class: Puppet::Type.type(:file).defaultprovider, clear: nil) }
+    let(:file_provider) { class_double('provider', class: Puppet::Type.type(:file).defaultprovider, clear: nil) }
 
     before(:each) do
-      Puppet::Type.type(:file).defaultprovider.stubs(:new).returns(file_provider)
+      allow(Puppet::Type.type(:file).defaultprovider).to receive(:new).and_return(file_provider)
     end
 
     [:private_key, :certificate].each do |file|
       it "should autorequire for #{file} #file" do
-        test_jks = Puppet::Type.type(:java_ks).new(jks_resource)
+        test_jks = described_class.new(jks_resource)
         test_file = Puppet::Type.type(:file).new(title: jks_resource[file])
 
         Puppet::Resource::Catalog.new :testing do |conf|
@@ -205,7 +205,7 @@ describe Puppet::Type.type(:java_ks) do
         expect(rel.source.ref).to eq(test_file.ref)
       end
       it "should autorequire for #{file} #jks" do
-        test_jks = Puppet::Type.type(:java_ks).new(jks_resource)
+        test_jks = described_class.new(jks_resource)
         test_file = Puppet::Type.type(:file).new(title: jks_resource[file])
 
         Puppet::Resource::Catalog.new :testing do |conf|
@@ -218,7 +218,7 @@ describe Puppet::Type.type(:java_ks) do
     end
 
     it 'autorequires for the :target directory #file' do
-      test_jks = Puppet::Type.type(:java_ks).new(jks_resource)
+      test_jks = described_class.new(jks_resource)
       test_file = Puppet::Type.type(:file).new(title: ::File.dirname(jks_resource[:target]))
 
       Puppet::Resource::Catalog.new :testing do |conf|
@@ -229,7 +229,7 @@ describe Puppet::Type.type(:java_ks) do
       expect(rel.source.ref).to eq(test_file.ref)
     end
     it 'autorequires for the :target directory #jks' do
-      test_jks = Puppet::Type.type(:java_ks).new(jks_resource)
+      test_jks = described_class.new(jks_resource)
       test_file = Puppet::Type.type(:file).new(title: ::File.dirname(jks_resource[:target]))
 
       Puppet::Resource::Catalog.new :testing do |conf|


### PR DESCRIPTION
- PDK Update Ran
- Code coverage enabled
- `spec/unit/puppet/provider/java_ks/keytool_spec.rb` converted from mocha to rspec-mock
- `spec/unit/puppet/type/java_ks_spec.rb` converted from mocha to rspec-mock