### PR TITLE
Correct jceks symbol comparison

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -219,7 +219,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
         '-keystore', @resource[:target],
         '-alias', @resource[:name]
       ]
-      cmd += ['-storetype', storetype] if storetype == 'jceks'
+      cmd += ['-storetype', storetype] if storetype == :jceks
       tmpfile = password_file
       output = run_command(cmd, false, tmpfile)
       tmpfile.close!


### PR DESCRIPTION
The provider is comparing the storetype to a string in one instance
instead of a symbol, resulting in a failure anytime is needs to run the
command that is built from that comparison.