### PR TITLE
add storetype parameter comparison to 'destroy' method

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -261,6 +261,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
       '-alias', @resource[:name],
       '-keystore', @resource[:target]
     ]
+    cmd += ['-storetype', storetype] if storetype == :jceks
     tmpfile = password_file
     run_command(cmd, false, tmpfile)
     tmpfile.close!

--- a/spec/unit/puppet/provider/java_ks/keytool_spec.rb
+++ b/spec/unit/puppet/provider/java_ks/keytool_spec.rb
@@ -211,7 +211,7 @@ describe Puppet::Type.type(:java_ks).provider(:keytool) do
 
   describe 'when removing entries from keytool' do
     it 'executes keytool with a specific set of options' do
-      expect(provider).to receive(:run_command).with(['mykeytool', '-delete', '-alias', resource[:name], '-keystore', resource[:target]], any_args)
+      expect(provider).to receive(:run_command).with(['mykeytool', '-delete', '-alias', resource[:name], '-keystore', resource[:target], '-storetype', resource[:storetype]], any_args)
       provider.destroy
     end
   end


### PR DESCRIPTION
Without this comparison, attempting to destroy a jceks keystore will
fail.