### PR TITLE
Change latest/current comparison to account for chains

### DIFF
--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -33,7 +33,7 @@ Puppet::Type.newtype(:java_ks) do
           return true if is == :absent
         when :latest
           unless is == :absent
-            return true if provider.latest == provider.current
+            return true if provider.latest.include? provider.current
           end
         end
       end


### PR DESCRIPTION
When certificate chains are being compared, the 'latest' one can have
several SHA1 checksums in them, which the code will flatten and join
into a single string. This gets compared against what is in the
keystore, which only has a single SHA1 checksum in it. This results in a
failed check every time.

Instead of checking for equality between those two values, we can just
check to see if 'latest' contains 'current'.