### PR TITLE
(IAC-1423) - Fix for Keytool Test Error

### DIFF
--- a/spec/acceptance/chain_key_spec.rb
+++ b/spec/acceptance/chain_key_spec.rb
@@ -7,6 +7,20 @@ describe 'managing intermediate certificates' do
   describe 'managing combined and seperate java chain keys' do
     include_context 'common variables'
 
+    it 'verifies keytool is setup', unless: os[:family] == 'windows' do
+      i = 0
+      loop do
+        keytool_status = run_shell('keytool')
+        break if keytool_status['exit_code'] == 0
+        if i == 10
+          exit 1
+        else
+          i += 1
+          sleep 1.minute
+        end
+      end
+    end
+
     it 'creates two private key with chain certs' do
       pp = <<-MANIFEST
         java_ks { 'combined.example.com:#{@temp_dir}chain_combined_key.ks':


### PR DESCRIPTION
On certain machines the test can begin to run before java and keytool have finished setting up. This puts a wait in to try and prevent this and give the machines enough time to get ready.