### PR TITLE
(MODULES-11067) Fix keytool output parsing

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -173,10 +173,10 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
 
   # Extracts the fingerprints of a given output
   def extract_fingerprint(output)
-    fps = Array.new
-    output.scan(%r{^Certificate fingerprints:(.*?)Signature?}m).flatten.each { |certblock|
+    fps = []
+    output.scan(%r{^Certificate fingerprints:(.*?)Signature?}m).flatten.each do |certblock|
       fps.push(certblock.scan(%r{^\s+\S+:\s+(\S+)}m))
-    }
+    end
     fps.flatten.sort.join('/')
   end
 

--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -173,7 +173,11 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
 
   # Extracts the fingerprints of a given output
   def extract_fingerprint(output)
-    output.scan(%r{Certificate fingerprints:\n\s+(?:MD5:  .*\n\s+)?SHA1: (.*)}).flatten.join('/')
+    fps = Array.new
+    output.scan(%r{^Certificate fingerprints:(.*?)Signature?}m).flatten.each { |certblock|
+      fps.push(certblock.scan(%r{^\s+\S+:\s+(\S+)}m))
+    }
+    fps.flatten.sort.join('/')
   end
 
   # Reading the fingerprint of the certificate on disk.


### PR DESCRIPTION
Change extract_fingerprint() function to scan for all certificate
fingerprints and sort before joining them.

The latest version of keytool doesn't always return certs in the same
order, so extract_fingerprint() can return a different string for
identical certs. Also extract_fingerprint() only scans for MD5 and SHA1
fingerprints; it should scan for all fingerprints.