### PR TITLE
Fix fingerprint comparison

### DIFF
--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -35,7 +35,9 @@ Puppet::Type.newtype(:java_ks) do
           return true if is == :absent
         when :latest
           unless is == :absent
-            return true if provider.latest.include? provider.current
+            current = provider.current.split('/')
+            latest = provider.latest.split('/')
+            return true if current.to_set.subset?(latest.to_set)
           end
         end
       end

--- a/spec/unit/puppet/type/java_ks_spec.rb
+++ b/spec/unit/puppet/type/java_ks_spec.rb
@@ -184,6 +184,14 @@ describe Puppet::Type.type(:java_ks) do
       allow(provider_var).to receive(:current).and_return('66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A')
       expect(described_class.new(jks).property(:ensure)).to be_insync(:present)
     end
+
+    it 'insync? should return true if subset of sha1 fingerprints match and state is :present' do
+      jks = jks_resource.dup
+      jks[:ensure] = :latest
+      allow(provider_var).to receive(:latest).and_return('9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A:E7:8F:6A/66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A')
+      allow(provider_var).to receive(:current).and_return('66:9B:8B:23:4C:6A:9A:08:F6:4E:B6:01:23:EA:5A')
+      expect(described_class.new(jks).property(:ensure)).to be_insync(:present)
+    end
   end
 
   describe 'when file resources are in the catalog' do


### PR DESCRIPTION
Given input:
current fingerprint say "a/c/d"
latest fingerprint say "a/b/c/d"

doing `latest.include? current` would fail.

A set comparison is more accurate here.