### PR TITLE
pdksync - (IAC-1709) - Add Support for Debian 11

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,8 @@
       "operatingsystemrelease": [
         "8",
         "9",
-        "10"
+        "10",
+        "11"
       ]
     },
     {

--- a/spec/acceptance/pkcs12_spec.rb
+++ b/spec/acceptance/pkcs12_spec.rb
@@ -50,7 +50,8 @@ describe 'managing java pkcs12', unless: (os[:family] == 'sles' || (os[:family] 
 
       idempotent_apply(pp)
 
-      expectations = if os[:family] == 'windows' || (os[:family] == 'ubuntu' && os[:release] == '20.04')
+      expectations = if os[:family] == 'windows' || (os[:family] == 'ubuntu' && os[:release] == '20.04') ||
+                        (os[:family] == 'debian' && os[:release] =~ %r{^11})
                        [
                          %r{Alias name: leaf cert},
                          %r{Entry type: (keyEntry|PrivateKeyEntry)},

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -195,6 +195,8 @@ RSpec.shared_context 'common variables' do
       @resource_path = "['C:/Program Files/Java/jdk1.#{java_major}.0_#{java_minor}/bin/']"
     when 'ubuntu'
       @ensure_ks = 'present' if os[:release] == '20.04'
+    when 'debian'
+      @ensure_ks = 'present' if os[:release].match?(%r{^11})
     end
   end
 end


### PR DESCRIPTION
(IAC-1709) - Add Support for Debian 11
pdk version: `2.1.0` 
