### PR TITLE
Add support for certificate_content and private_key_content parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ java_ks { 'broker.example.com:/etc/activemq/broker.ks':
 }
 ```
 
+For use cases where you want to fetch the certificate data from a secure store, like vault, you can use the `_content` attributes. Here is an example:
+
+```puppet
+java_ks { 'broker.example.com:/etc/activemq/broker.ks':
+  ensure              => latest,
+  certificate_content => $certificate_data_fetched_from_secure_store,
+  private_key_content => $private_key_data_fetched_from_secure_store
+  password            => 'albatros',
+  password_fail_reset => true,
+}
+```
+
+We recommend using the data type `Senstive` for the attributes `certificate_content` and `private_key_content`. But These attributes also support a regular `String` data type. The `_content` attributes are mutual exclusive with their file-based variants.
+
+
 You can also use Hiera by passing params to the java_ks::config class:
 
 ```yaml

--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -280,11 +280,36 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
   end
 
   def certificate
-    @resource[:certificate]
+    return @resource[:certificate] if  @resource[:certificate]
+
+    # When no certificate file is specified, we infer the usage of
+    # certificate content and create a tempfile containing this value.
+    # we leave it to to the tempfile to clean it up after the pupet run exists.
+    file = Tempfile.new('certificate')
+    # Check if the specified value is a Sensitive data type. If so, unwrap it and use
+    # the value.
+    content = @resource[:certificate_content].respond_to?(:unwrap) ? @resource[:certificate_content].unwrap : @resource[:certificate_content]
+    file.write(content)
+    file.close
+    file.path
   end
 
   def private_key
-    @resource[:private_key]
+    return @resource[:private_key] if @resource[:private_key]
+    if @resource[:private_key_content]
+
+
+      # When no private key file is specified, we infer the usage of
+      # private key content and create a tempfile containing this value.
+      # we leave it to to the tempfile to clean it up after the pupet run exists.
+      file = Tempfile.new('private_key')
+      # Check if the specified value is a Sensitive data type. If so, unwrap it and use
+      # the value.
+      content = @resource[:private_key_content].respond_to?(:unwrap) ? @resource[:private_key_content].unwrap : @resource[:private_key_content]
+      file.write(content)
+      file.close
+      file.path
+    end
   end
 
   def private_key_type

--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -66,10 +66,13 @@ Puppet::Type.newtype(:java_ks) do
   end
 
   newparam(:certificate) do
-    desc 'A server certificate, followed by zero or more intermediate certificate authorities.
-      All certificates will be placed in the keystore.  This will autorequire the specified file.'
+    desc 'A file containing a server certificate, followed by zero or more intermediate certificate authorities.
+      All certificates will be placed in the keystore. This will autorequire the specified file.'
+  end
 
-    isrequired
+  newparam(:certificate_content) do
+    desc 'A string containing a server certificate, followed by zero or more intermediate certificate authorities.
+      All certificates will be placed in the keystore.'
   end
 
   newparam(:storetype) do
@@ -82,7 +85,16 @@ Puppet::Type.newtype(:java_ks) do
   newparam(:private_key) do
     desc 'If you want an application to be a server and encrypt traffic,
       you will need a private key.  Private key entries in a keystore must be
-      accompanied by a signed certificate for the keytool provider. This will autorequire the specified file.'
+      accompanied by a signed certificate for the keytool provider. This parameter
+      allows you to specify the file name containing the private key. This will autorequire 
+      the specified file.'
+  end
+
+  newparam(:private_key_content) do
+    desc 'If you want an application to be a server and encrypt traffic,
+      you will need a private key.  Private key entries in a keystore must be
+      accompanied by a signed certificate for the keytool provider. This parameter allows you to specify the content
+      of the private key.'
   end
 
   newparam(:private_key_type) do
@@ -228,6 +240,18 @@ Puppet::Type.newtype(:java_ks) do
   end
 
   validate do
+    unless value(:certificate) || value(:certificate_content)
+      raise Puppet::Error, "You must pass one of 'certificate' or 'certificate_content'"
+    end
+
+    if value(:certificate) && value(:certificate_content)
+      raise Puppet::Error, "You must pass either 'certificate' or 'certificate_content', not both."
+    end
+
+    if value(:private_key) && value(:private_key_content)
+      raise Puppet::Error, "You must pass either 'private_key' or 'private_key_content', not both."
+    end
+
     if value(:password) && value(:password_file)
       raise Puppet::Error, "You must pass either 'password' or 'password_file', not both."
     end

--- a/spec/acceptance/content_spec.rb
+++ b/spec/acceptance/content_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+RSpec.shared_examples 'a private key creator' do |sensitive|
+  it 'creates a private key' do
+    pp = if sensitive
+      <<-MANIFEST
+        java_ks { 'broker.example.com:#{temp_dir}private_key.ts':
+          ensure              => #{@ensure_ks},
+          certificate_content => "#{ca_content}",
+          private_key_content => "#{priv_key_content}",
+          password            => 'puppet',
+          path                => #{@resource_path},
+        }
+      MANIFEST
+    else
+      <<-MANIFEST
+        java_ks { 'broker.example.com:#{temp_dir}private_key.ts':
+          ensure              => #{@ensure_ks},
+          certificate_content => Sensitive("#{ca_content}"),
+          private_key_content => Sensitive("#{priv_key_content}"),
+          password            => 'puppet',
+          path                => #{@resource_path},
+        }
+      MANIFEST
+    end
+    idempotent_apply(pp)
+  end
+
+  expectations = [
+    %r{Alias name: broker\.example\.com},
+    %r{Entry type: (keyEntry|PrivateKeyEntry)},
+    %r{CN=Test CA},
+  ]
+  it 'verifies the private key' do
+    run_shell(keytool_command("-list -v -keystore #{temp_dir}private_key.ts -storepass puppet"), expect_failures: true) do |r|
+      expectations.each do |expect|
+        expect(r.stdout).to match(expect)
+      end
+    end
+  end
+end
+
+describe 'using certificate_content and private_key_content' do
+  include_context 'common variables'
+  let(:ca_content) { File.read('spec/acceptance/certs/ca.pem') }
+  let(:priv_key_content) { File.read('spec/acceptance/certs/privkey.pem') }
+
+  context 'Using data type String' do
+    it_behaves_like 'a private key creator',  false
+  end
+
+  context 'Using data type Sensitive' do
+    it_behaves_like 'a private key creator',  true
+  end
+end

--- a/spec/unit/puppet/type/java_ks_spec.rb
+++ b/spec/unit/puppet/type/java_ks_spec.rb
@@ -117,6 +117,30 @@ describe Puppet::Type.type(:java_ks) do
       }.to raise_error(Puppet::Error)
     end
 
+    it 'fails if both :certificate and :certificate_content are provided' do
+      jks = jks_resource.dup
+      jks[:certificate_content] = 'certificate_content'
+      expect {
+        described_class.new(jks)
+      }.to raise_error(Puppet::Error, %r{You must pass either})
+    end
+
+    it 'fails if neither :certificate or :certificate_content is provided' do
+      jks = jks_resource.dup
+      jks.delete(:certificate)
+      expect {
+        described_class.new(jks)
+      }.to raise_error(Puppet::Error, %r{You must pass one of})
+    end
+
+    it 'fails if both :private_key and :private_key_content are provided' do
+      jks = jks_resource.dup
+      jks[:private_key_content] = 'private_content'
+      expect {
+        described_class.new(jks)
+      }.to raise_error(Puppet::Error, %r{You must pass either})
+    end
+
     it 'fails if both :password and :password_file are provided' do
       jks = jks_resource.dup
       jks[:password_file] = '/path/to/password_file'


### PR DESCRIPTION
The current implementation only allows you to pass a file name to the `certificate` and `private_key` parameters. When you are fetching certificates from vault or another secure store, you'll first have to save them to a file. This is very innconveniant.

This PR add's the parameters `certificate_content` and `private_key_content`. These parameters are mutually exclusive from their file counterparts.

With this change, you can now fetch a certificate and/or a password from vault (through a hiera lookup for example) and use it directly on the type.

Because these values can be sensitive, both of the new parameters support passing the value as a sensitive data type.
