### PR TITLE
pdksync - (GH-cat-11) Certify Support for Ubuntu 22.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -60,7 +60,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     },
     {

--- a/spec/acceptance/pkcs12_spec.rb
+++ b/spec/acceptance/pkcs12_spec.rb
@@ -50,7 +50,7 @@ describe 'managing java pkcs12', unless: (os[:family] == 'sles' || (os[:family] 
 
       idempotent_apply(pp)
 
-      expectations = if os[:family] == 'windows' || (os[:family] == 'ubuntu' && os[:release] == '20.04') ||
+      expectations = if os[:family] == 'windows' || (os[:family] == 'ubuntu' && ['20.04', '22.04'].include?(os[:release])) ||
                         (os[:family] == 'debian' && os[:release] =~ %r{^11})
                        [
                          %r{Alias name: leaf cert},

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -195,7 +195,7 @@ RSpec.shared_context 'common variables' do
       @keytool_path = "C:/Program Files/Java/jdk1.#{java_major}.0_#{java_minor}/bin/"
       @resource_path = "['C:/Program Files/Java/jdk1.#{java_major}.0_#{java_minor}/bin/']"
     when 'ubuntu'
-      @ensure_ks = 'present' if os[:release] == '20.04'
+      @ensure_ks = 'present' if ['20.04', '22.04'].include?(os[:release])
     when 'debian'
       @ensure_ks = 'present' if os[:release].match?(%r{^11})
     end


### PR DESCRIPTION
(GH-cat-11) Certify Support for Ubuntu 22.04
pdk version: `2.4.0` 
