### PR TITLE
(CONT-186) Set `-deststoretype`

### DIFF
--- a/lib/puppet/provider/java_ks/keytool.rb
+++ b/lib/puppet/provider/java_ks/keytool.rb
@@ -95,6 +95,7 @@ Puppet::Type.type(:java_ks).provide(:keytool) do
     ]
     cmd << '-trustcacerts' if @resource[:trustcacerts] == :true
     cmd += ['-destkeypass', @resource[:destkeypass]] unless @resource[:destkeypass].nil?
+    cmd += ['-deststoretype', storetype] unless storetype.nil?
 
     pwfile = password_file
     run_command(cmd, @resource[:target], pwfile)

--- a/spec/unit/puppet/provider/java_ks/keytool_spec.rb
+++ b/spec/unit/puppet/provider/java_ks/keytool_spec.rb
@@ -152,7 +152,8 @@ describe Puppet::Type.type(:java_ks).provider(:keytool) do
       it 'executes openssl and keytool with specific options' do
         expect(provider).to receive(:to_pkcs12).with("#{temp_dir}testing.stuff")
         expect(provider).to receive(:run_command).with(['mykeytool', '-importkeystore', '-srcstoretype', 'PKCS12', '-destkeystore',
-                                                        resource[:target], '-srckeystore', "#{temp_dir}testing.stuff", '-alias', resource[:name]], any_args)
+                                                        resource[:target], '-srckeystore', "#{temp_dir}testing.stuff", '-alias',
+                                                        resource[:name], '-deststoretype', :jceks], any_args)
         provider.import_ks
       end
 
@@ -161,7 +162,8 @@ describe Puppet::Type.type(:java_ks).provider(:keytool) do
         dkp[:destkeypass] = 'keypass'
         expect(provider).to receive(:to_pkcs12).with("#{temp_dir}testing.stuff")
         expect(provider).to receive(:run_command).with(['mykeytool', '-importkeystore', '-srcstoretype', 'PKCS12', '-destkeystore',
-                                                        dkp[:target], '-srckeystore', "#{temp_dir}testing.stuff", '-alias', dkp[:name], '-destkeypass', dkp[:destkeypass]], any_args)
+                                                        dkp[:target], '-srckeystore', "#{temp_dir}testing.stuff", '-alias', dkp[:name],
+                                                        '-destkeypass', dkp[:destkeypass], '-deststoretype', dkp[:storetype]], any_args)
         provider.import_ks
       end
     end


### PR DESCRIPTION
Prior to this commit `-deststoretype` was not set, resulting in key stores being created in the default type.
This has been done through implementation of the existing variable `storetype` rather than  creating a new one as I cannot foresee an instance where the two would differentiate.