### PR TITLE
(CAT-2100) Add Debian 12 support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,7 @@ fixtures:
     provision: 'https://github.com/puppetlabs/provision.git'
     puppet_agent:
       repo: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-      ref: v4.13.0
+      ref: v4.21.0
   forge_modules:
     chocolatey: "puppetlabs/chocolatey"
     java: "puppetlabs/java"

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "10",
-        "11"
+        "11",
+        "12"
       ]
     },
     {

--- a/spec/acceptance/pkcs12_spec.rb
+++ b/spec/acceptance/pkcs12_spec.rb
@@ -22,12 +22,22 @@ describe 'managing java pkcs12', unless: (os[:family] == 'sles' || (os[:family] 
       idempotent_apply(pp)
     end
 
-    expectations = [
-      %r{Alias name: leaf cert},
-      %r{Entry type: (keyEntry|PrivateKeyEntry)},
-      %r{Certificate chain length: 3},
-      %r{^Serial number: 5.*^Serial number: 4.*^Serial number: 3}m,
-    ]
+    expectations = if os[:family] == 'debian' && os[:release] =~ %r{^12}
+                     [
+                       %r{Alias name: leaf cert},
+                       %r{Entry type: (keyEntry|PrivateKeyEntry)},
+                       %r{Certificate chain length: 2},
+                       %r{^Serial number: 5.*^Serial number: 6}m,
+                     ]
+                   else
+                     [
+                       %r{Alias name: leaf cert},
+                       %r{Entry type: (keyEntry|PrivateKeyEntry)},
+                       %r{Certificate chain length: 3},
+                       %r{^Serial number: 5.*^Serial number: 4.*^Serial number: 3}m,
+                     ]
+                   end
+
     it 'verifies the private key and chain' do
       run_shell(keytool_command("-list -v -keystore #{@temp_dir}pkcs12.ks -storepass puppet"), expect_failures: true) do |r|
         expectations.each do |expect|
@@ -93,12 +103,22 @@ describe 'managing java pkcs12', unless: (os[:family] == 'sles' || (os[:family] 
       idempotent_apply(pp)
     end
 
-    expectations = [
-      %r{Alias name: leaf_cert},
-      %r{Entry type: (keyEntry|PrivateKeyEntry)},
-      %r{Certificate chain length: 3},
-      %r{^Serial number: 5.*^Serial number: 4.*^Serial number: 3}m,
-    ]
+    expectations = if os[:family] == 'debian' && os[:release] =~ %r{^12}
+                     [
+                       %r{Alias name: leaf_cert},
+                       %r{Entry type: (keyEntry|PrivateKeyEntry)},
+                       %r{Certificate chain length: 2},
+                       %r{^Serial number: 5.*^Serial number: 6}m,
+                     ]
+                   else
+                     [
+                       %r{Alias name: leaf_cert},
+                       %r{Entry type: (keyEntry|PrivateKeyEntry)},
+                       %r{Certificate chain length: 3},
+                       %r{^Serial number: 5.*^Serial number: 4.*^Serial number: 3}m,
+                     ]
+                   end
+
     it 'verifies the private key and chain' do
       run_shell(keytool_command("-list -v -keystore #{@temp_dir}pkcs12.ks -storepass puppet"), expect_failures: true) do |r|
         expectations.each do |expect|
@@ -133,12 +153,21 @@ describe 'managing java pkcs12', unless: (os[:family] == 'sles' || (os[:family] 
       idempotent_apply(pp)
     end
 
-    expectations = [
-      %r{Alias name: leaf_cert},
-      %r{Entry type: (keyEntry|PrivateKeyEntry)},
-      %r{Certificate chain length: 3},
-      %r{^Serial number: 5.*^Serial number: 4.*^Serial number: 3}m,
-    ]
+    expectations = if os[:family] == 'debian' && os[:release] =~ %r{^12}
+                     [
+                       %r{Alias name: leaf_cert},
+                       %r{Entry type: (keyEntry|PrivateKeyEntry)},
+                       %r{Certificate chain length: 2},
+                       %r{^Serial number: 5.*^Serial number: 6}m,
+                     ]
+                   else
+                     [
+                       %r{Alias name: leaf_cert},
+                       %r{Entry type: (keyEntry|PrivateKeyEntry)},
+                       %r{Certificate chain length: 3},
+                       %r{^Serial number: 5.*^Serial number: 4.*^Serial number: 3}m,
+                     ]
+                   end
     it 'verifies the private key and chain' do
       run_shell(keytool_command("-list -v -keystore #{@temp_dir}pkcs12.ks -storepass puppet"), expect_failures: true) do |r|
         expectations.each do |expect|

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -197,7 +197,7 @@ RSpec.shared_context 'with common variables' do
     when 'ubuntu'
       @ensure_ks = 'present' if ['20.04', '22.04'].include?(os[:release])
     when 'debian'
-      @ensure_ks = 'present' if os[:release].match?(%r{^11})
+      @ensure_ks = 'present' if os[:release].match?(%r{^11|12})
     end
   end
 end


### PR DESCRIPTION
## Summary
Add Debian 12 support

## Additional Context

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)