### PR TITLE
Fix boolean parameters

### DIFF
--- a/lib/puppet/type/java_ks.rb
+++ b/lib/puppet/type/java_ks.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'puppet/parameter/boolean'
+
 Puppet::Type.newtype(:java_ks) do
   @doc = 'Manages the entries in a java keystore, and uses composite namevars to
   accomplish the same alias spread across multiple target keystores.'
@@ -132,14 +134,12 @@ Puppet::Type.newtype(:java_ks) do
       keystore. This cannot be used together with :password, but you must pass at least one of these parameters.'
   end
 
-  newparam(:password_fail_reset) do
+  newparam(:password_fail_reset, boolean: true, parent: Puppet::Parameter::Boolean) do
     desc "If the supplied password does not succeed in unlocking the
       keystore file, then delete the keystore file and create a new one.
       Default: false."
 
-    newvalues(true, false)
-
-    defaultto false
+    defaultto :false
   end
 
   newparam(:destkeypass) do
@@ -156,13 +156,11 @@ Puppet::Type.newtype(:java_ks) do
     end
   end
 
-  newparam(:trustcacerts) do
+  newparam(:trustcacerts, boolean: true, parent: Puppet::Parameter::Boolean) do
     desc "Certificate authorities aren't by default trusted so if you are adding a CA you need to set this to true.
      Defaults to :false."
 
-    newvalues(true, false)
-
-    defaultto false
+    defaultto :false
   end
 
   newparam(:path) do

--- a/spec/unit/puppet/type/java_ks_spec.rb
+++ b/spec/unit/puppet/type/java_ks_spec.rb
@@ -102,8 +102,22 @@ describe Puppet::Type.type(:java_ks) do
       expect(described_class.new(jks)[:name]).to eq(jks_resource[:name])
     end
 
-    it 'has false as the default value to :trustcacerts when parameter not provided' do
-      expect(described_class.new(jks_resource)[:trustcacerts]).to be_nil
+    it 'resource[:trustcacerts] is falsey when parameter not provided' do
+      expect(described_class.new(jks_resource)[:trustcacerts]).to be_falsey
+    end
+
+    it 'resource[:trustcacerts] is the boolean `false` when set to `false`' do
+      jks = jks_resource.dup
+      jks[:trustcacerts] = false
+
+      expect(described_class.new(jks)[:trustcacerts]).to be false
+    end
+
+    it 'resource[:trustcacerts] is the boolean `true` when set to `true`' do
+      jks = jks_resource.dup
+      jks[:trustcacerts] = true
+
+      expect(described_class.new(jks)[:trustcacerts]).to be true
     end
 
     it 'has :rsa as the default value for :private_key_type' do
@@ -175,8 +189,22 @@ describe Puppet::Type.type(:java_ks) do
       }.to raise_error(Puppet::Error, %r{length 6})
     end
 
-    it 'has :false value to :password_fail_reset when parameter not provided' do
-      expect(described_class.new(jks_resource)[:password_fail_reset]).to be_nil
+    it 'resource[:password_fail_reset] is falsey when parameter not provided' do
+      expect(described_class.new(jks_resource)[:password_fail_reset]).to be_falsey
+    end
+
+    it 'resource[:password_fail_reset] is the boolean `false` when parameter set to `false`' do
+      jks = jks_resource.dup
+      jks[:password_fail_reset] = false
+
+      expect(described_class.new(jks)[:password_fail_reset]).to be false
+    end
+
+    it 'resource[:password_fail_reset] is the boolean `true` when parameter set to `true`' do
+      jks = jks_resource.dup
+      jks[:password_fail_reset] = true
+
+      expect(described_class.new(jks)[:password_fail_reset]).to be true
     end
 
     it 'fails if :source_password is not provided for pkcs12 :storetype' do


### PR DESCRIPTION
The unsafe rubocop fixes done in
189ac295bdd35196297476957c9f0b6e21e47829 broke the boolean parameters.

Before this commit, if you explicitly tried to set either of them to `false`, they would actually be set to the symbol `:false` with is not falsey so would act as if you'd set them to `true`.