### PR TITLE
Pin puppet_litmus unconditionally; drop the no-token litmus 1.x fallback

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -8,6 +8,9 @@ Gemfile:
   optional:
     ":development":
     - gem: ruby-pwsh
+  overrides:
+    - gem: 'puppet_litmus'
+      version: '~> 2.0'
 spec/spec_helper.rb:
   mock_with: ":rspec"
   coverage_report: true

--- a/Gemfile
+++ b/Gemfile
@@ -43,8 +43,7 @@ group :development, :release_prep do
   gem "puppet-blacksmith", '~> 7.0',      require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 2.0',   require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
+  gem "puppet_litmus", '~> 2.0',   require: false, platforms: [:ruby, :x64_mingw]
   gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',     require: false
 end


### PR DESCRIPTION
## Why

Mend's CI-upload scan for this repo (`puppet_modules` product in the CVE
remediation hub) resolves `Gemfile` **without** `PUPPET_FORGE_TOKEN` set, so
it walks the `if ENV["PUPPET_FORGE_TOKEN"].to_s.empty?` branch and reports
ancient `puppet_litmus` **1.x** (and its stale transitive deps, e.g. old
bolt/jwt) as the real dependency tree — inflating CVE counts for a version
nobody actually tests with. A normal `bundle install` (which does have the
token, e.g. in this repo's own CI) resolves `puppet_litmus` **2.x** fine.

Raised in <https://perforce.slack.com/archives/C0BHQDASRRA/p1788771803282819>.
Same root cause and fix `puppet_agent` already applied in
[PA-7824](https://github.com/puppetlabs/puppetlabs-puppet_agent/commit/7b8e24efc911679f0d72b83e8dea2ec2310139a2).

## What

- `Gemfile`: drop the token-gated fallback, pin `puppet_litmus` unconditionally
  to the version already used on the "token present" branch.
- `.sync.yml`: add the matching `Gemfile: overrides:` entry so a future
  `pdk update` doesn't regenerate the fallback from the shared pdk-templates
  default (this is the same mechanism already used in modules that don't have
  this bug, e.g. `puppetlabs-stdlib`).

## Test plan

- [ ] CI green (bundle install / rubocop / spec)